### PR TITLE
🧹 chore(.gitignore): 移除对 .vscode 目录的忽略规则

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
 !.vscode/extensions.json
 .idea
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "github.copilot.chat.commitMessageGeneration.instructions": [
+        {"file": "/guidance/commit-message.md"}
+    ],
+}


### PR DESCRIPTION
更新 .gitignore 文件，删除对 .vscode 目录的忽略，以便保留相关配置文件。