### PR TITLE
📝 docs(backend-project-task): 将数据访问层由 Repository 改为 Mapper

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,20 +1,23 @@
 ---
-applyTo: '**'
+applyTo: "**"
 ---
+
 你现在是一名资深的云原生全栈工程师，正在开发一个用于展示个人博客的完整网站。
 请始终遵循以下架构原则和代码规范进行协作，包括但不限于 Git 提交流程、目录结构、技术栈选型、代码组织、测试与部署策略等。
 
 **核心技术栈:**
+
 - 前端: React, TypeScript, Vite, TailWindCSS, shadcn/ui, pnpm
-- 后端: Java, Spring Boot 3, Maven, PostgreSQL, Spring Data JPA & MyBatis-Plus, Spring Security & JWT, Redis, Kafka
+- 后端: Java, Spring Boot 3, Maven, PostgreSQL, MyBatis-Plus, Spring Security & JWT, Redis, Kafka
 - 状态管理: 优先使用 Zustand 进行全局状态管理。
 - 部署：Docker + Kubernetes + Github Actions。
 
 **前端核心架构原则:**
+
 1. **结构**: 严格遵循我提供的目录结构 (`api/`, `components/`, `hooks/`, `pages/` 等)。应预留 `lib/` 用于工具函数、`config/` 用于常量和全局配置，`stores/` 用于 Zustand 状态。
 2. **组件化**: 遵循原子设计理念。`components/ui` 是原子组件（封装自 shadcn/ui 或 Tailwind 原子类），`components/common` 是复合业务组件，`components/layout` 用于全局结构组件（如 Header/Footer）。
 3. **类型安全**: 必须使用严格的 TypeScript，**禁用 any（通过 tsconfig 限制）**。所有后端接口响应、DTO 定义应集中在 `src/types/api.ts` 等文件中维护。
-4. **API调用**: 所有后端 API 请求都必须通过 `src/api/` 目录下的服务函数进行封装，避免在组件中直接使用 axios/fetch。封装应内置统一错误处理、loading 状态处理。
+4. **API 调用**: 所有后端 API 请求都必须通过 `src/api/` 目录下的服务函数进行封装，避免在组件中直接使用 axios/fetch。封装应内置统一错误处理、loading 状态处理。
 5. **状态管理**: 全局状态使用 Zustand。每个功能模块单独定义 Store 文件，并通过 selector 优化性能。全局登录用户状态、权限、菜单等应集中在 `authStore` 管理。
 6. **路由权限控制**: 页面级权限控制必须通过全局 `PrivateRoute` 组件封装，结合 Zustand 中的 `user.roles[]` 判断权限，支持嵌套路由拦截与重定向。
 7. **OAuth 登录流程**: 需支持 GitHub/Gitee OAuth 登录流程，登录完成后前端解析回调参数（`code`），调用 `api/auth/oauth` 获取 JWT 并存入 Zustand 状态 + localStorage，自动跳转回首页。
@@ -25,10 +28,11 @@ applyTo: '**'
 12. **代码注释**: 对复杂的业务逻辑、自定义 Hook、Zustand Store 和复合组件，应使用 TSDoc 注释（`/** */`）进行结构描述与参数说明。
 
 **后端核心架构原则:**
+
 1. **分层架构**: 严格遵守 Controller -> Service -> Repository/Mapper 的分层结构。Controller 必须保持"薄"。
 2. **DTO 模式**: 所有 Controller 的输入和输出都必须是 DTO 对象，严禁泄露 Entity。DTO 中应使用 Jakarta Bean Validation (如 `@NotBlank`, `@Size`) 进行参数校验。
-3. **统一API响应**: 所有API成功响应都必须封装在 `{ "code": 200, "message": "Success", "data": ... }` 结构中。全局异常处理器负责处理所有错误响应。
-4. **数据持久化**: 简单的单表 CRUD 使用 Spring Data JPA；复杂查询、多表连接和自定义 SQL 使用 MyBatis-Plus。
+3. **统一 API 响应**: 所有 API 成功响应都必须封装在 `{ "code": 200, "message": "Success", "data": ... }` 结构中。全局异常处理器负责处理所有错误响应。
+4. **数据持久化**: 使用 MyBatis-Plus。
 5. **安全**: 所有接口默认需要 JWT 认证，公共接口需在 Spring Security 配置中显式放行。
 6. **日志**: 在关键业务逻辑和异常发生处，使用 SLF4J 记录结构化日志。
 7. **代码注释**: 对 Service 层的公开方法和复杂的业务逻辑，应添加 JavaDoc 注释。
@@ -42,24 +46,27 @@ applyTo: '**'
 15. **前期集成测试支持**: 初始化阶段必须为用户登录、注册等核心接口预留测试类，使用 MockMvc 编写集成测试，确保认证与安全模块稳定。
 
 **测试原则:**
+
 - **前端**: 使用 Jest 和 React Testing Library 为关键组件和 Hooks 编写单元测试。
 - **后端**: 使用 JUnit 5 和 Mockito 为 Service 层编写单元测试。Controller 层可编写集成测试。
 
-**DevOps原则:**
+**DevOps 原则:**
+
 - **命名**: Docker 镜像名应为 `[your-dockerhub-username]/kisesaki-blog-[frontend|backend]`。
 - **CI/CD**: GitHub Actions 的 workflow 应包含代码检查 (lint)、测试、构建和镜像推送等步骤。
 
-**Git相关规范:**
+**Git 相关规范:**
+
 - **分支创建规则**: 所有任务在开始之前都要创建对应的分支，如 `feature/frontend-api-client-with-auth-store`。完成后输出标准化的提交信息，具体提交由我自己完成。
-- **分支管理**: 
+- **分支管理**:
   - `main`: 主分支，保持稳定，只接受经过测试的代码
   - `develop`: 开发分支，用于集成各个功能分支
   - `feature/frontend-xxx`: 前端功能开发分支
   - `feature/backend-xxx`: 后端功能开发分支
-  - `bugfix/frontend-xxx`: 前端bug修复分支
-  - `bugfix/backend-xxx`: 后端bug修复分支
+  - `bugfix/frontend-xxx`: 前端 bug 修复分支
+  - `bugfix/backend-xxx`: 后端 bug 修复分支
   - `hotfix/xxx`: 紧急修复分支，直接从 main 分支创建
-  - `docs/xxx`: 文档更新分支（如README、API文档等）
+  - `docs/xxx`: 文档更新分支（如 README、API 文档等）
   - `chore/xxx`: 构建工具、依赖更新等维护性分支
   - `refactor/frontend-xxx`: 前端重构分支
   - `refactor/backend-xxx`: 后端重构分支
@@ -77,7 +84,7 @@ applyTo: '**'
      - 🐋 chore: 其他不影响源代码的变更
      - ⏪ revert: 回滚某次提交
   2. **范围（scope）**：可选，说明影响范围（如模块、文件名等）
-  3. **描述（subject）**：必填，简要描述本次提交的目的，建议不超过50字
+  3. **描述（subject）**：必填，简要描述本次提交的目的，建议不超过 50 字
   4. **详细描述（body）**：必填，对本次提交的详细描述
   5. **关联问题（footer）**：可选，关联的 issue 编号等
 - **Pull Request**: PR 标题应简洁明了，描述应包含变更内容和影响范围。PR 必须通过代码审查后才能合并。

--- a/.github/prompts/backend-project-task.md
+++ b/.github/prompts/backend-project-task.md
@@ -20,39 +20,58 @@
     │   ├── AuthController.java
     │   ├── AuthService.java
     │   ├── dto                      # 认证相关 DTO
-    │   ├── entity                   # 角色权限实体
-    │   ├── repository               # 认证相关数据访问
+    ---
+
+## 🔄 **开发规范提醒**
+
+- ✨ **按功能划分包结构** (每个业务模块独立管理)
+- 🔷 **严格遵循分层架构** (Controller -> Service -> Mapper)
+- 📝 **所有接口使用 DTO 进行数据传输**
+- 🎨 **使用 Jakarta Bean Validation 进行参数校验**
+- 🔐 **统一异常处理和日志记录**
+- 🧪 **核心功能需要编写单元测试**
+- 📊 **重要操作需要添加 Kafka 事件发布**
+- 🛡️ **敏感操作需要权限验证**
+- 🗄️ **MyBatis-Plus 数据访问规范**:
+  - 简单 CRUD 使用 `BaseMapper` 提供的基础方法
+  - 复杂查询使用 `QueryWrapper` 或 `LambdaQueryWrapper`
+  - 多表关联查询编写自定义 XML 映射文件
+  - 分页查询使用 MyBatis-Plus 分页插件
+  - 所有 Mapper 接口继承 `BaseMapper<Entity>`
+  - Service 层可选择继承 `ServiceImpl<Mapper, Entity>` 获得基础服务方法
+- 🏗️ **每个功能模块内部保持高内聚，模块之间保持低耦合**y                   # 角色权限实体
+    │   ├── mapper                   # 认证相关数据访问
     │   └── security                 # Security 配置
     ├── user                         # 用户管理模块
     │   ├── UserController.java
     │   ├── UserService.java
     │   ├── dto                      # 用户相关 DTO
     │   ├── entity                   # 用户实体
-    │   └── repository               # 用户数据访问
+    │   └── mapper                   # 用户数据访问
     ├── post                         # 文章管理模块
     │   ├── PostController.java
     │   ├── PostService.java
     │   ├── dto                      # 文章相关 DTO
     │   ├── entity                   # 文章实体
-    │   └── repository               # 文章数据访问
+    │   └── mapper                   # 文章数据访问
     ├── category                     # 分类管理模块
     │   ├── CategoryController.java
     │   ├── CategoryService.java
     │   ├── dto
     │   ├── entity
-    │   └── repository
+    │   └── mapper
     ├── tag                          # 标签管理模块
     │   ├── TagController.java
     │   ├── TagService.java
     │   ├── dto
     │   ├── entity
-    │   └── repository
+    │   └── mapper
     ├── comment                      # 评论管理模块
     │   ├── CommentController.java
     │   ├── CommentService.java
     │   ├── dto
     │   ├── entity
-    │   └── repository
+    │   └── mapper
     ├── interaction                  # 互动功能模块 (点赞、收藏、关注)
     │   ├── InteractionController.java
     │   ├── LikeService.java
@@ -60,33 +79,33 @@
     │   ├── FollowService.java
     │   ├── dto
     │   ├── entity
-    │   └── repository
+    │   └── mapper
     ├── admin                        # 管理员功能模块
     │   ├── AdminController.java
     │   ├── AdminUserService.java
     │   ├── AdminPostService.java
     │   ├── DashboardService.java
     │   ├── dto
-    │   └── repository
+    │   └── mapper
     ├── media                        # 媒体文件管理模块
     │   ├── MediaController.java
     │   ├── FileUploadService.java
     │   ├── MediaResourceService.java
     │   ├── dto
     │   ├── entity
-    │   └── repository
+    │   └── mapper
     ├── notification                 # 通知系统模块
     │   ├── NotificationController.java
     │   ├── NotificationService.java
     │   ├── EmailService.java
     │   ├── dto
     │   ├── entity
-    │   └── repository
+    │   └── mapper
     └── statistics                   # 统计分析模块
         ├── StatisticsController.java
         ├── StatisticsService.java
         ├── dto
-        └── repository
+        └── mapper
 ```
 
 ## 🚀 阶段一：项目基础架构与安全体系 (Foundation & Security)
@@ -94,12 +113,13 @@
 ### 🔧 **1. 项目初始化与环境配置**
 
 > **优先级**: 最高 ⭐⭐⭐
+> **技术栈**: 纯 MyBatis-Plus 数据访问层，无 Spring Data JPA
 
 - **📦 Maven 依赖配置** (`pom.xml`):
 
   - [ ] Spring Boot 3.x 核心依赖
   - [ ] Spring Security 6.x + OAuth2 Client
-  - [ ] Spring Data JPA + MyBatis-Plus
+  - [ ] MyBatis-Plus (纯MyBatis-Plus，无Spring Data JPA)
   - [ ] PostgreSQL Driver + HikariCP
   - [ ] Redis + Spring Data Redis
   - [ ] Kafka + Spring Kafka
@@ -155,12 +175,12 @@
     - [ ] `Permission` - 权限实体 (使用 Enum 管理权限点)
     - [ ] `UserRole` - 用户角色关联 (多对多中间表)
     - [ ] `RolePermission` - 角色权限关联 (多对多中间表)
-  - [ ] **数据访问层** (`auth.repository`):
+  - [ ] **数据访问层** (`auth.mapper`):
 
-    - [ ] `RoleRepository` - 角色数据访问
-    - [ ] `PermissionRepository` - 权限数据访问
-    - [ ] `UserRoleRepository` - 用户角色关联访问
-    - [ ] `RolePermissionRepository` - 角色权限关联访问
+    - [ ] `RoleMapper` - 角色数据访问
+    - [ ] `PermissionMapper` - 权限数据访问
+    - [ ] `UserRoleMapper` - 用户角色关联访问
+    - [ ] `RolePermissionMapper` - 角色权限关联访问
 - **👤 用户管理模块** (`com.kisesaki.blog.user`):
 
   - [ ] **实体层** (`user.entity`):
@@ -168,11 +188,11 @@
     - [ ] `User` - 用户基础信息
     - [ ] `UserProfile` - 用户扩展信息
     - [ ] `UserSettings` - 用户个性化设置
-  - [ ] **数据访问层** (`user.repository`):
+  - [ ] **数据访问层** (`user.mapper`):
 
-    - [ ] `UserRepository` - 用户数据访问
-    - [ ] `UserProfileRepository` - 用户扩展信息访问
-    - [ ] `UserSettingsRepository` - 用户设置访问
+    - [ ] `UserMapper` - 用户数据访问
+    - [ ] `UserProfileMapper` - 用户扩展信息访问
+    - [ ] `UserSettingsMapper` - 用户设置访问
 
 ### 🔒 **4. Spring Security 配置**
 
@@ -183,6 +203,7 @@
   - [ ] `SecurityConfig` - 主安全配置类
   - [ ] `CorsConfig` - CORS 跨域配置
   - [ ] `RedisConfig` - Redis 配置
+  - [ ] `MybatisPlusConfig` - MyBatis-Plus 配置
   - [ ] `KafkaConfig` - Kafka 配置
 - **🔐 认证安全** (`com.kisesaki.blog.auth.security`):
 
@@ -192,6 +213,13 @@
   - [ ] `OAuth2UserService` - OAuth2 用户信息服务
   - [ ] 接口权限配置 (公开接口放行，管理接口权限控制)
   - [ ] 密码编码器配置
+- **📊 MyBatis-Plus 配置** (`com.kisesaki.blog.config`):
+
+  - [ ] `@MapperScan("com.kisesaki.blog.**.mapper")` - Mapper 包扫描
+  - [ ] 分页插件配置 (PostgreSQL)
+  - [ ] 逻辑删除配置
+  - [ ] 字段填充策略 (创建时间、更新时间)
+  - [ ] 乐观锁插件配置
 
 ---
 
@@ -283,43 +311,43 @@
     - [ ] `PostRevision` - 文章版本历史
     - [ ] `PostMeta` - 文章元数据 (SEO 相关)
     - [ ] `PostTag` - 文章标签关联
-  - [ ] **数据访问层** (`post.repository`):
+  - [ ] **数据访问层** (`post.mapper`):
 
-    - [ ] `PostRepository` - 文章数据访问 (JPA + 自定义查询)
-    - [ ] `PostRevisionRepository` - 文章版本访问
-    - [ ] `PostMetaRepository` - 文章元数据访问
+    - [ ] `PostMapper` - 文章数据访问 (MyBatis-Plus BaseMapper + 自定义查询)
+    - [ ] `PostRevisionMapper` - 文章版本访问
+    - [ ] `PostMetaMapper` - 文章元数据访问
 - **📁 分类管理模块** (`com.kisesaki.blog.category`):
 
   - [ ] **实体层** (`category.entity`):
 
     - [ ] `Category` - 分类实体 (支持层级结构)
-  - [ ] **数据访问层** (`category.repository`):
+  - [ ] **数据访问层** (`category.mapper`):
 
-    - [ ] `CategoryRepository` - 分类数据访问
+    - [ ] `CategoryMapper` - 分类数据访问
 - **🏷️ 标签管理模块** (`com.kisesaki.blog.tag`):
 
   - [ ] **实体层** (`tag.entity`):
 
     - [ ] `Tag` - 标签实体
-  - [ ] **数据访问层** (`tag.repository`):
+  - [ ] **数据访问层** (`tag.mapper`):
 
-    - [ ] `TagRepository` - 标签数据访问
+    - [ ] `TagMapper` - 标签数据访问
 - **💬 评论管理模块** (`com.kisesaki.blog.comment`):
 
   - [ ] **实体层** (`comment.entity`):
 
     - [ ] `Comment` - 评论实体 (支持嵌套回复)
-  - [ ] **数据访问层** (`comment.repository`):
+  - [ ] **数据访问层** (`comment.mapper`):
 
-    - [ ] `CommentRepository` - 评论数据访问
+    - [ ] `CommentMapper` - 评论数据访问
 - **📷 媒体管理模块** (`com.kisesaki.blog.media`):
 
   - [ ] **实体层** (`media.entity`):
 
     - [ ] `MediaResource` - 媒体资源实体
-  - [ ] **数据访问层** (`media.repository`):
+  - [ ] **数据访问层** (`media.mapper`):
 
-    - [ ] `MediaResourceRepository` - 媒体资源访问
+    - [ ] `MediaResourceMapper` - 媒体资源访问
 
 ### 📋 **9. 博客 DTO 设计**
 
@@ -356,13 +384,13 @@
 
   - [ ] **服务层**:
 
-    - [ ] `PostService` - 文章核心服务
+    - [ ] `PostService` - 文章核心服务 (继承 MyBatis-Plus ServiceImpl)
 
       - [ ] `getPublishedPosts()` - 获取已发布文章列表
       - [ ] `getPostBySlug()` - 根据 slug 获取文章详情 (带缓存)
       - [ ] `getPostsByCategory()` - 按分类获取文章
-      - [ ] `getPostsByTag()` - 按标签获取文章
-      - [ ] `searchPosts()` - 搜索文章
+      - [ ] `getPostsByTag()` - 按标签获取文章 (多对多关联查询)
+      - [ ] `searchPosts()` - 搜索文章 (PostgreSQL 全文搜索)
       - [ ] `getArchivePosts()` - 获取归档文章
       - [ ] `incrementViewCount()` - 增加浏览量
   - [ ] **控制器层**:
@@ -484,12 +512,12 @@
     - [ ] `Favorite` - 收藏实体
     - [ ] `Following` - 关注关系实体
     - [ ] `ViewLog` - 浏览记录实体
-  - [ ] **数据访问层** (`interaction.repository`):
+  - [ ] **数据访问层** (`interaction.mapper`):
 
-    - [ ] `LikeRepository` - 点赞数据访问
-    - [ ] `FavoriteRepository` - 收藏数据访问
-    - [ ] `FollowingRepository` - 关注数据访问
-    - [ ] `ViewLogRepository` - 浏览记录访问
+    - [ ] `LikeMapper` - 点赞数据访问
+    - [ ] `FavoriteMapper` - 收藏数据访问
+    - [ ] `FollowingMapper` - 关注数据访问
+    - [ ] `ViewLogMapper` - 浏览记录访问
   - [ ] **服务层**:
 
     - [ ] `LikeService` - 点赞服务
@@ -765,7 +793,7 @@
 ## 🔄 **开发规范提醒**
 
 - ✨ **按功能划分包结构** (每个业务模块独立管理)
-- 🔷 **严格遵循分层架构** (Controller -> Service -> Repository)
+- **🔷 严格遵循分层架构** (Controller -> Service -> Mapper)
 - 📝 **所有接口使用 DTO 进行数据传输**
 - 🎨 **使用 Jakarta Bean Validation 进行参数校验**
 - 🔐 **统一异常处理和日志记录**


### PR DESCRIPTION
- 将 `.github/prompts/backend-project-task.md` 中所有模块的 `repository` 替换为 `mapper`
- 将类/接口命名由 `*Repository` 更新为 `*Mapper`（文档层面）；
- 同时移除对 Spring Data JPA 的说明，明确定义为“纯 MyBatis-Plus”技术栈
- 补充 MyBatis-Plus 配置（`@MapperScan`、分页/逻辑删除/乐观锁等）与访问规范（BaseMapper、ServiceImpl、QueryWrapper、XML 映射）。