### PR TITLE
✨ feat(redis): 新增 Redis 通用服务与 Key 前缀支持`

### DIFF
--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/security/jwt/RefreshTokenService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/security/jwt/RefreshTokenService.java
@@ -13,6 +13,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
+import com.kisesaki.blog.user.Keys.UserKey;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,9 +30,9 @@ import lombok.extern.slf4j.Slf4j;
  * 6. 支持批量操作和并发安全
  * 
  * Redis存储结构：
- * - refresh_token:{username}:device:{deviceId} -> token内容
- * - user_devices:{username} -> Set<deviceId>
- * - token_metadata:{username}:{deviceId} -> 元数据JSON
+ * - UserKey:device:refreshToken:{username}:{deviceId} -> token内容
+ * - UserKey:devices:{username} -> Set<deviceId>
+ * - UserKey:device:metadata:{username}:{deviceId} -> 元数据JSON
  * 
  * @author KiseSaki
  */
@@ -55,27 +57,6 @@ public class RefreshTokenService {
      */
     @Value("${kisesaki.blog.security.max-devices-per-user:10}")
     private Integer maxDevicesPerUser;
-
-    /**
-     * 设备token在Redis中的键名模板
-     * 格式：refresh_token:{username}:device:{deviceId}
-     * 用于存储具体的token字符串
-     */
-    private static final String DEVICE_TOKEN_PREFIX = "refresh_token:%s:device:%s";
-
-    /**
-     * 用户设备集合在Redis中的键名模板
-     * 格式：user_devices:{username}
-     * 用于存储用户所有登录设备的ID集合
-     */
-    private static final String USER_DEVICES_KEY = "user_devices:%s";
-
-    /**
-     * token元数据在Redis中的键名模板
-     * 格式：token_metadata:{username}:{deviceId}
-     * 用于存储设备信息、创建时间、最后使用时间等元数据
-     */
-    private static final String TOKEN_METADATA_KEY = "token_metadata:%s:%s";
 
     /**
      * 创建并存储 Refresh Token
@@ -115,11 +96,11 @@ public class RefreshTokenService {
     private String createDeviceToken(String username, Authentication authentication, String deviceId,
             String deviceInfo) {
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
-        String redisKey = String.format(DEVICE_TOKEN_PREFIX, username, deviceId);
+        String redisKey = UserKey.buildDeviceRefreshTokenKey(username, deviceId);
         // 设备token存储键
-        String userDevicesKey = String.format(USER_DEVICES_KEY, username);
+        String userDevicesKey = UserKey.buildUserDevicesKey(username);
         // 元数据存储键
-        String metadataKey = String.format(TOKEN_METADATA_KEY, username, deviceId);
+        String metadataKey = UserKey.buildDeviceMetadataKey(username, deviceId);
 
         // 检查是否是设备重复登录
         String oldToken = stringRedisTemplate.opsForValue().get(redisKey);
@@ -151,11 +132,11 @@ public class RefreshTokenService {
                 // ARGV[1]，新生成的 Refresh Token 字符串，用于存储到 Redis
                 refreshToken,
                 // ARGV[2]，token 过期时间（毫秒），用于设置键的 PX（毫秒过期）
-                String.valueOf(refreshTokenExpirationMs),
+                String.valueOf(UserKey.DEVICE_REFRESH_TOKEN.getExpireSeconds() * 1000L),
                 // ARGV[3]，设备 ID，用于添加到用户设备集合。
                 deviceId,
                 // ARGV[4]，设备集合的过期时间（秒），与 token 过期时间一致
-                String.valueOf(refreshTokenExpirationMs / 1000),
+                String.valueOf(UserKey.DEVICE_REFRESH_TOKEN.getExpireSeconds()),
                 // ARGV[5]，token 元数据 JSON 字符串（包含设备信息、创建时间等），存储到元数据键
                 metadata);
 
@@ -203,7 +184,7 @@ public class RefreshTokenService {
      */
     private boolean validateDeviceToken(String username, String refreshToken, String deviceId) {
         // 构建Redis键名
-        String redisKey = String.format(DEVICE_TOKEN_PREFIX, username, deviceId);
+        String redisKey = UserKey.buildDeviceRefreshTokenKey(username, deviceId);
         // 从Redis获取存储的token
         String storedToken = stringRedisTemplate.opsForValue().get(redisKey);
         // 比较提供的token和存储的token是否一致
@@ -220,7 +201,7 @@ public class RefreshTokenService {
      */
     private boolean validateAllDeviceTokens(String username, String refreshToken) {
         // 获取用户所有设备ID集合的Redis键
-        String userDevicesKey = String.format(USER_DEVICES_KEY, username);
+        String userDevicesKey = UserKey.buildUserDevicesKey(username);
         // 从Redis Set中获取所有设备ID
         Set<String> deviceIds = stringRedisTemplate.opsForSet().members(userDevicesKey);
 
@@ -260,7 +241,7 @@ public class RefreshTokenService {
 
         // 如果未删除成功，则遍历所有设备查找并删除匹配的token
         if (!deleted) {
-            String userDevicesKey = String.format(USER_DEVICES_KEY, username);
+            String userDevicesKey = UserKey.buildUserDevicesKey(username);
             Set<String> deviceIds = stringRedisTemplate.opsForSet().members(userDevicesKey);
 
             if (deviceIds != null) {
@@ -284,15 +265,15 @@ public class RefreshTokenService {
      */
     private boolean deleteSpecificDeviceToken(String username, String refreshToken, String deviceId) {
         // 构建设备token的Redis键
-        String redisKey = String.format(DEVICE_TOKEN_PREFIX, username, deviceId);
+        String redisKey = UserKey.buildDeviceRefreshTokenKey(username, deviceId);
         // 获取存储的token进行验证
         String storedToken = stringRedisTemplate.opsForValue().get(redisKey);
 
         // 验证token是否匹配
         if (refreshToken.equals(storedToken)) {
             // 构建相关的Redis键
-            String userDevicesKey = String.format(USER_DEVICES_KEY, username); // 用户设备集合键
-            String metadataKey = String.format(TOKEN_METADATA_KEY, username, deviceId); // 元数据键
+            String userDevicesKey = UserKey.buildUserDevicesKey(username); // 用户设备集合键
+            String metadataKey = UserKey.buildDeviceMetadataKey(username, deviceId); // 元数据键
 
             // 使用 Lua 脚本确保原子性删除操作
             // 删除token、从设备集合中移除设备ID、删除元数据
@@ -330,14 +311,14 @@ public class RefreshTokenService {
      * @param username 用户名
      */
     public void deleteAllRefreshTokens(String username) {
-        String userDevicesKey = String.format(USER_DEVICES_KEY, username);
+        String userDevicesKey = UserKey.buildUserDevicesKey(username);
         Set<String> deviceIds = stringRedisTemplate.opsForSet().members(userDevicesKey);
 
         if (deviceIds != null && !deviceIds.isEmpty()) {
             // 批量删除所有设备的token和元数据
             for (String deviceId : deviceIds) {
-                String redisKey = String.format(DEVICE_TOKEN_PREFIX, username, deviceId);
-                String metadataKey = String.format(TOKEN_METADATA_KEY, username, deviceId);
+                String redisKey = UserKey.buildDeviceRefreshTokenKey(username, deviceId);
+                String metadataKey = UserKey.buildDeviceMetadataKey(username, deviceId);
                 stringRedisTemplate.delete(redisKey);
                 stringRedisTemplate.delete(metadataKey);
             }
@@ -364,9 +345,9 @@ public class RefreshTokenService {
      * @param deviceId 设备ID
      */
     public void deleteDeviceToken(String username, String deviceId) {
-        String redisKey = String.format(DEVICE_TOKEN_PREFIX, username, deviceId);
-        String userDevicesKey = String.format(USER_DEVICES_KEY, username);
-        String metadataKey = String.format(TOKEN_METADATA_KEY, username, deviceId);
+        String redisKey = UserKey.buildDeviceRefreshTokenKey(username, deviceId);
+        String userDevicesKey = UserKey.buildUserDevicesKey(username);
+        String metadataKey = UserKey.buildDeviceMetadataKey(username, deviceId);
 
         // 使用 Lua 脚本确保原子性删除
         String luaScript = """
@@ -397,7 +378,7 @@ public class RefreshTokenService {
      * @return 设备ID集合，如果用户没有登录设备则返回空集合
      */
     public Set<String> getUserDevices(String username) {
-        String userDevicesKey = String.format(USER_DEVICES_KEY, username);
+        String userDevicesKey = UserKey.buildUserDevicesKey(username);
         return stringRedisTemplate.opsForSet().members(userDevicesKey);
     }
 
@@ -413,7 +394,7 @@ public class RefreshTokenService {
      * @return 活跃设备数量，如果用户没有登录设备则返回0
      */
     public Long getActiveDeviceCount(String username) {
-        String userDevicesKey = String.format(USER_DEVICES_KEY, username);
+        String userDevicesKey = UserKey.buildUserDevicesKey(username);
         return stringRedisTemplate.opsForSet().size(userDevicesKey);
     }
 
@@ -430,18 +411,18 @@ public class RefreshTokenService {
      * @param username 用户名
      */
     public void cleanExpiredTokens(String username) {
-        String userDevicesKey = String.format(USER_DEVICES_KEY, username);
+        String userDevicesKey = UserKey.buildUserDevicesKey(username);
         Set<String> deviceIds = stringRedisTemplate.opsForSet().members(userDevicesKey);
 
         if (deviceIds != null && !deviceIds.isEmpty()) {
             int cleanedCount = 0;
             for (String deviceId : deviceIds) {
-                String redisKey = String.format(DEVICE_TOKEN_PREFIX, username, deviceId);
+                String redisKey = UserKey.buildDeviceRefreshTokenKey(username, deviceId);
                 // 检查token是否还存在
                 if (!stringRedisTemplate.hasKey(redisKey)) {
                     // token已过期，清理相关引用
                     stringRedisTemplate.opsForSet().remove(userDevicesKey, deviceId);
-                    String metadataKey = String.format(TOKEN_METADATA_KEY, username, deviceId);
+                    String metadataKey = UserKey.buildDeviceMetadataKey(username, deviceId);
                     stringRedisTemplate.delete(metadataKey);
                     cleanedCount++;
                 }
@@ -471,7 +452,7 @@ public class RefreshTokenService {
      * @return 元数据JSON字符串，如果不存在则返回null
      */
     public String getTokenMetadata(String username, String deviceId) {
-        String metadataKey = String.format(TOKEN_METADATA_KEY, username, deviceId);
+        String metadataKey = UserKey.buildDeviceMetadataKey(username, deviceId);
         return stringRedisTemplate.opsForValue().get(metadataKey);
     }
 
@@ -490,7 +471,7 @@ public class RefreshTokenService {
             log.warn("用户 {} 设备数量超限，当前: {}, 最大: {}", username, deviceCount, maxDevicesPerUser);
 
             // 构建用户设备集合的Redis键
-            String userDevicesKey = String.format(USER_DEVICES_KEY, username);
+            String userDevicesKey = UserKey.buildUserDevicesKey(username);
 
             // 删除最旧的设备（这里使用集合的任意元素，实际场景可以根据时间戳排序）
             Set<String> deviceIds = stringRedisTemplate.opsForSet().members(userDevicesKey);
@@ -534,7 +515,7 @@ public class RefreshTokenService {
      */
     private void updateTokenLastUsed(String username, String deviceId) {
         // 构建元数据的Redis键
-        String metadataKey = String.format(TOKEN_METADATA_KEY, username, deviceId);
+        String metadataKey = UserKey.buildDeviceMetadataKey(username, deviceId);
         // 获取当前元数据
         String metadata = stringRedisTemplate.opsForValue().get(metadataKey);
 
@@ -548,8 +529,8 @@ public class RefreshTokenService {
                     "\"lastUsedAt\": \"" + newTimestamp + "\""); // 替换为新的时间戳
 
             // 更新Redis中的元数据，保持原有的TTL
-            stringRedisTemplate.opsForValue().set(metadataKey, updatedMetadata, refreshTokenExpirationMs,
-                    TimeUnit.MILLISECONDS);
+            stringRedisTemplate.opsForValue().set(metadataKey, updatedMetadata,
+                    UserKey.DEVICE_TOKEN_METADATA.getExpireSeconds(), TimeUnit.SECONDS);
         }
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/redis/BasePrefix.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/redis/BasePrefix.java
@@ -1,0 +1,39 @@
+package com.kisesaki.blog.redis;
+
+/**
+ * Redis Key 前缀基类。
+ *
+ * 该类实现了 KeyPrefix 接口，提供了前缀和过期时间的基本实现。
+ * 通过继承该类，可以方便地创建具有特定前缀和过期时间的 Redis 键前缀类。
+ *
+ * 例如，可以创建一个 UserPrefix 类，继承自 BasePrefix，并设置特定的前缀和过期时间。
+ * 这样在使用 Redis 时，可以通过 UserPrefix 来管理与用户相关的数据键。
+ *
+ * 注意：前缀通常用于组织和区分不同类型的数据，过期时间用于控制数据的生命周期。
+ */
+public abstract class BasePrefix implements KeyPrefix{
+    private final int expireSeconds;
+    private final String prefix;
+
+    // 默认0代表永不过期
+    public BasePrefix(String prefix) {
+        this(0, prefix);
+    }
+
+    public BasePrefix(int expireSeconds, String prefix) {
+        this.expireSeconds = expireSeconds;
+        this.prefix = prefix;
+    }
+
+    @Override
+    public int getExpireSeconds() {
+        return expireSeconds;
+    }
+
+    @Override
+    public String getPrefix() {
+        // 获取类名作为前缀的一部分，确保唯一性
+        String className = getClass().getSimpleName();
+        return className + ":" + prefix;
+    }
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/redis/KeyPrefix.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/redis/KeyPrefix.java
@@ -1,0 +1,24 @@
+package com.kisesaki.blog.redis;
+
+/** Redis Key 前缀接口。
+ * 实现该接口的类用于定义 Redis 键的前缀，帮助组织和管理 Redis 中存储的数据。
+ * 通过使用前缀，可以避免键冲突，并使得键更具可读性和结构化。
+ * 例如，可以为不同的业务模块或数据类型定义不同的前缀，如 "user:", "order:" 等。
+ * 这样在存储和检索数据时，可以更容易地识别和操作相关的键。
+ * 注意：实现该接口的类通常会包含一个方法来返回具体的前缀字符串。
+ */
+public interface KeyPrefix {
+    /**
+     * 获取 Redis 键的前缀字符串。
+     *
+     * @return 前缀字符串
+     */
+    String getPrefix();
+
+    /**
+     * 获取前缀的过期时间（秒）。
+     *
+     * @return 过期时间，单位为秒
+     */
+    int getExpireSeconds();
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/redis/RedisService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/redis/RedisService.java
@@ -1,0 +1,749 @@
+package com.kisesaki.blog.redis;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+import jakarta.annotation.Resource;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Redis 统一服务类。
+ * 
+ * 提供了对 Redis 的通用操作封装，支持 KeyPrefix 体系，
+ * 包含基本的 CRUD 操作、过期时间管理、分布式锁等功能。
+ * 
+ * 主要功能：
+ * - 基本的 get/set/delete 操作
+ * - 带过期时间的数据操作
+ * - 列表、集合、哈希等数据结构操作
+ * - 分布式锁实现
+ * - 批量操作支持
+ * - 原子操作支持
+ * 
+ * @author KiseSaki
+ * @since 2025-09-01
+ */
+@Service
+@Slf4j
+public class RedisService {
+
+    @Resource
+    private RedisTemplate<String, Object> redisTemplate;
+
+    // ========== 基本操作 ==========
+
+    /**
+     * 设置键值对
+     *
+     * @param key   键
+     * @param value 值
+     * @return 是否成功
+     */
+    public boolean set(String key, Object value) {
+        try {
+            redisTemplate.opsForValue().set(key, value);
+            return true;
+        } catch (Exception e) {
+            log.error("Redis set operation failed: key={}, error={}", key, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * 设置键值对（使用 KeyPrefix）
+     *
+     * @param prefix KeyPrefix 实例
+     * @param key    键后缀
+     * @param value  值
+     * @return 是否成功
+     */
+    public boolean set(KeyPrefix prefix, String key, Object value) {
+        String realKey = prefix.getPrefix() + ":" + key;
+        boolean result = set(realKey, value);
+        if (result && prefix.getExpireSeconds() > 0) {
+            expire(realKey, prefix.getExpireSeconds());
+        }
+        return result;
+    }
+
+    /**
+     * 设置键值对并指定过期时间
+     *
+     * @param key     键
+     * @param value   值
+     * @param timeout 过期时间
+     * @param unit    时间单位
+     * @return 是否成功
+     */
+    public boolean set(String key, Object value, long timeout, TimeUnit unit) {
+        try {
+            redisTemplate.opsForValue().set(key, value, timeout, unit);
+            return true;
+        } catch (Exception e) {
+            log.error("Redis set with expire operation failed: key={}, timeout={}, error={}",
+                    key, timeout, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * 获取值
+     *
+     * @param key 键
+     * @return 值
+     */
+    public Object get(String key) {
+        try {
+            return redisTemplate.opsForValue().get(key);
+        } catch (Exception e) {
+            log.error("Redis get operation failed: key={}, error={}", key, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * 获取值（使用 KeyPrefix）
+     *
+     * @param prefix KeyPrefix 实例
+     * @param key    键后缀
+     * @return 值
+     */
+    public Object get(KeyPrefix prefix, String key) {
+        return get(prefix.getPrefix() + ":" + key);
+    }
+
+    /**
+     * 获取值并转换为指定类型
+     *
+     * @param key   键
+     * @param clazz 目标类型
+     * @param <T>   泛型类型
+     * @return 转换后的值
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T get(String key, Class<T> clazz) {
+        try {
+            Object value = get(key);
+            if (value == null) {
+                return null;
+            }
+            if (clazz.isInstance(value)) {
+                return (T) value;
+            }
+            // 如果类型不匹配，可以在这里添加类型转换逻辑
+            log.warn("Type mismatch for key {}: expected {}, got {}",
+                    key, clazz.getSimpleName(), value.getClass().getSimpleName());
+            return null;
+        } catch (Exception e) {
+            log.error("Redis get with type conversion failed: key={}, type={}, error={}",
+                    key, clazz.getSimpleName(), e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * 获取值并转换为指定类型（使用 KeyPrefix）
+     *
+     * @param prefix KeyPrefix 实例
+     * @param key    键后缀
+     * @param clazz  目标类型
+     * @param <T>    泛型类型
+     * @return 转换后的值
+     */
+    public <T> T get(KeyPrefix prefix, String key, Class<T> clazz) {
+        return get(prefix.getPrefix() + ":" + key, clazz);
+    }
+
+    /**
+     * 删除键
+     *
+     * @param keys 键列表
+     * @return 删除的键数量
+     */
+    public long delete(String... keys) {
+        try {
+            if (keys == null || keys.length == 0) {
+                return 0;
+            }
+            Long count = redisTemplate.delete(Arrays.asList(keys));
+            return count != null ? count : 0;
+        } catch (Exception e) {
+            log.error("Redis delete operation failed: keys={}, error={}",
+                    Arrays.toString(keys), e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    /**
+     * 删除键（使用 KeyPrefix）
+     *
+     * @param prefix KeyPrefix 实例
+     * @param keys   键后缀列表
+     * @return 删除的键数量
+     */
+    public long delete(KeyPrefix prefix, String... keys) {
+        if (keys == null || keys.length == 0) {
+            return 0;
+        }
+        String[] realKeys = Arrays.stream(keys)
+                .map(key -> prefix.getPrefix() + ":" + key)
+                .toArray(String[]::new);
+        return delete(realKeys);
+    }
+
+    /**
+     * 检查键是否存在
+     *
+     * @param key 键
+     * @return 是否存在
+     */
+    public boolean exists(String key) {
+        try {
+            Boolean result = redisTemplate.hasKey(key);
+            return result != null && result;
+        } catch (Exception e) {
+            log.error("Redis exists operation failed: key={}, error={}", key, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * 检查键是否存在（使用 KeyPrefix）
+     *
+     * @param prefix KeyPrefix 实例
+     * @param key    键后缀
+     * @return 是否存在
+     */
+    public boolean exists(KeyPrefix prefix, String key) {
+        return exists(prefix.getPrefix() + ":" + key);
+    }
+
+    // ========== 过期时间操作 ==========
+
+    /**
+     * 设置过期时间
+     *
+     * @param key     键
+     * @param timeout 过期时间
+     * @param unit    时间单位
+     * @return 是否成功
+     */
+    public boolean expire(String key, long timeout, TimeUnit unit) {
+        try {
+            Boolean result = redisTemplate.expire(key, timeout, unit);
+            return result != null && result;
+        } catch (Exception e) {
+            log.error("Redis expire operation failed: key={}, timeout={}, error={}",
+                    key, timeout, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * 设置过期时间（秒）
+     *
+     * @param key     键
+     * @param seconds 过期时间（秒）
+     * @return 是否成功
+     */
+    public boolean expire(String key, long seconds) {
+        return expire(key, seconds, TimeUnit.SECONDS);
+    }
+
+    /**
+     * 获取剩余过期时间
+     *
+     * @param key 键
+     * @return 剩余过期时间（秒），-1表示永不过期，-2表示键不存在
+     */
+    public long getExpire(String key) {
+        try {
+            Long expire = redisTemplate.getExpire(key, TimeUnit.SECONDS);
+            return expire != null ? expire : -2;
+        } catch (Exception e) {
+            log.error("Redis getExpire operation failed: key={}, error={}", key, e.getMessage(), e);
+            return -2;
+        }
+    }
+
+    // ========== Hash 操作 ==========
+
+    /**
+     * Hash 设置
+     *
+     * @param key   键
+     * @param field 字段
+     * @param value 值
+     * @return 是否成功
+     */
+    public boolean hSet(String key, String field, Object value) {
+        try {
+            redisTemplate.opsForHash().put(key, field, value);
+            return true;
+        } catch (Exception e) {
+            log.error("Redis hSet operation failed: key={}, field={}, error={}",
+                    key, field, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Hash 获取
+     *
+     * @param key   键
+     * @param field 字段
+     * @return 值
+     */
+    public Object hGet(String key, String field) {
+        try {
+            return redisTemplate.opsForHash().get(key, field);
+        } catch (Exception e) {
+            log.error("Redis hGet operation failed: key={}, field={}, error={}",
+                    key, field, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Hash 批量设置
+     *
+     * @param key 键
+     * @param map 字段值映射
+     * @return 是否成功
+     */
+    public boolean hMSet(String key, Map<String, Object> map) {
+        try {
+            if (map == null || map.isEmpty()) {
+                return true;
+            }
+            redisTemplate.opsForHash().putAll(key, map);
+            return true;
+        } catch (Exception e) {
+            log.error("Redis hMSet operation failed: key={}, error={}", key, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Hash 获取所有字段和值
+     *
+     * @param key 键
+     * @return 字段值映射
+     */
+    public Map<Object, Object> hGetAll(String key) {
+        try {
+            return redisTemplate.opsForHash().entries(key);
+        } catch (Exception e) {
+            log.error("Redis hGetAll operation failed: key={}, error={}", key, e.getMessage(), e);
+            return new HashMap<>();
+        }
+    }
+
+    /**
+     * Hash 删除字段
+     *
+     * @param key    键
+     * @param fields 字段列表
+     * @return 删除的字段数量
+     */
+    public long hDelete(String key, Object... fields) {
+        try {
+            if (fields == null || fields.length == 0) {
+                return 0;
+            }
+            Long count = redisTemplate.opsForHash().delete(key, fields);
+            return count != null ? count : 0;
+        } catch (Exception e) {
+            log.error("Redis hDelete operation failed: key={}, fields={}, error={}",
+                    key, Arrays.toString(fields), e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    // ========== Set 操作 ==========
+
+    /**
+     * Set 添加元素
+     *
+     * @param key    键
+     * @param values 值列表
+     * @return 添加的元素数量
+     */
+    public long sAdd(String key, Object... values) {
+        try {
+            if (values == null || values.length == 0) {
+                return 0;
+            }
+            Long count = redisTemplate.opsForSet().add(key, values);
+            return count != null ? count : 0;
+        } catch (Exception e) {
+            log.error("Redis sAdd operation failed: key={}, values={}, error={}",
+                    key, Arrays.toString(values), e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    /**
+     * Set 获取所有元素
+     *
+     * @param key 键
+     * @return 元素集合
+     */
+    public Set<Object> sMembers(String key) {
+        try {
+            Set<Object> members = redisTemplate.opsForSet().members(key);
+            return members != null ? members : new HashSet<>();
+        } catch (Exception e) {
+            log.error("Redis sMembers operation failed: key={}, error={}", key, e.getMessage(), e);
+            return new HashSet<>();
+        }
+    }
+
+    /**
+     * Set 移除元素
+     *
+     * @param key    键
+     * @param values 值列表
+     * @return 移除的元素数量
+     */
+    public long sRemove(String key, Object... values) {
+        try {
+            if (values == null || values.length == 0) {
+                return 0;
+            }
+            Long count = redisTemplate.opsForSet().remove(key, values);
+            return count != null ? count : 0;
+        } catch (Exception e) {
+            log.error("Redis sRemove operation failed: key={}, values={}, error={}",
+                    key, Arrays.toString(values), e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    /**
+     * Set 检查元素是否存在
+     *
+     * @param key   键
+     * @param value 值
+     * @return 是否存在
+     */
+    public boolean sIsMember(String key, Object value) {
+        try {
+            Boolean result = redisTemplate.opsForSet().isMember(key, value);
+            return result != null && result;
+        } catch (Exception e) {
+            log.error("Redis sIsMember operation failed: key={}, value={}, error={}",
+                    key, value, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    // ========== List 操作 ==========
+
+    /**
+     * List 左侧推入元素
+     *
+     * @param key    键
+     * @param values 值列表
+     * @return 推入后的列表长度
+     */
+    public long lPush(String key, Object... values) {
+        try {
+            if (values == null || values.length == 0) {
+                return 0;
+            }
+            Long count = redisTemplate.opsForList().leftPushAll(key, values);
+            return count != null ? count : 0;
+        } catch (Exception e) {
+            log.error("Redis lPush operation failed: key={}, values={}, error={}",
+                    key, Arrays.toString(values), e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    /**
+     * List 右侧推入元素
+     *
+     * @param key    键
+     * @param values 值列表
+     * @return 推入后的列表长度
+     */
+    public long rPush(String key, Object... values) {
+        try {
+            if (values == null || values.length == 0) {
+                return 0;
+            }
+            Long count = redisTemplate.opsForList().rightPushAll(key, values);
+            return count != null ? count : 0;
+        } catch (Exception e) {
+            log.error("Redis rPush operation failed: key={}, values={}, error={}",
+                    key, Arrays.toString(values), e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    /**
+     * List 左侧弹出元素
+     *
+     * @param key 键
+     * @return 弹出的元素
+     */
+    public Object lPop(String key) {
+        try {
+            return redisTemplate.opsForList().leftPop(key);
+        } catch (Exception e) {
+            log.error("Redis lPop operation failed: key={}, error={}", key, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * List 右侧弹出元素
+     *
+     * @param key 键
+     * @return 弹出的元素
+     */
+    public Object rPop(String key) {
+        try {
+            return redisTemplate.opsForList().rightPop(key);
+        } catch (Exception e) {
+            log.error("Redis rPop operation failed: key={}, error={}", key, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * List 获取指定范围的元素
+     *
+     * @param key   键
+     * @param start 开始位置
+     * @param end   结束位置
+     * @return 元素列表
+     */
+    public List<Object> lRange(String key, long start, long end) {
+        try {
+            List<Object> list = redisTemplate.opsForList().range(key, start, end);
+            return list != null ? list : new ArrayList<>();
+        } catch (Exception e) {
+            log.error("Redis lRange operation failed: key={}, start={}, end={}, error={}",
+                    key, start, end, e.getMessage(), e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * List 获取长度
+     *
+     * @param key 键
+     * @return 列表长度
+     */
+    public long lLen(String key) {
+        try {
+            Long length = redisTemplate.opsForList().size(key);
+            return length != null ? length : 0;
+        } catch (Exception e) {
+            log.error("Redis lLen operation failed: key={}, error={}", key, e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    // ========== 分布式锁 ==========
+
+    /**
+     * 尝试获取分布式锁
+     *
+     * @param lockKey    锁的键
+     * @param requestId  请求标识（用于释放锁时验证）
+     * @param expireTime 锁的过期时间（秒）
+     * @return 是否获取成功
+     */
+    public boolean tryLock(String lockKey, String requestId, long expireTime) {
+        try {
+            // setIfAbsent: 这个参数是实现互斥（mutual exclusion）的关键。
+            // 它告诉 Redis：“只有当这个 lockKey 不存在的时候，才设置它的值。如果已经存在了，就什么都不做。”
+            Boolean result = redisTemplate.opsForValue().setIfAbsent(lockKey, requestId,
+                    Duration.ofSeconds(expireTime));
+            return result != null && result;
+        } catch (Exception e) {
+            log.error("Redis tryLock operation failed: lockKey={}, requestId={}, error={}",
+                    lockKey, requestId, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * 释放分布式锁
+     *
+     * @param lockKey   锁的键
+     * @param requestId 请求标识（必须与获取锁时相同）
+     * @return 是否释放成功
+     */
+    public boolean releaseLock(String lockKey, String requestId) {
+        String script = "if redis.call('get', KEYS[1]) == ARGV[1] then " +
+                "return redis.call('del', KEYS[1]) " +
+                "else return 0 end";
+        try {
+            DefaultRedisScript<Long> redisScript = new DefaultRedisScript<>();
+            redisScript.setScriptText(script);
+            redisScript.setResultType(Long.class);
+
+            Long result = redisTemplate.execute(redisScript, Collections.singletonList(lockKey), requestId);
+            return result != null && result == 1L;
+        } catch (Exception e) {
+            log.error("Redis releaseLock operation failed: lockKey={}, requestId={}, error={}",
+                    lockKey, requestId, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    // ========== 原子操作 ==========
+
+    /**
+     * 原子递增
+     *
+     * @param key 键
+     * @return 递增后的值
+     */
+    public long increment(String key) {
+        try {
+            Long result = redisTemplate.opsForValue().increment(key);
+            return result != null ? result : 0L;
+        } catch (Exception e) {
+            log.error("Redis increment operation failed: key={}, error={}", key, e.getMessage(), e);
+            return 0L;
+        }
+    }
+
+    /**
+     * 原子递增指定步长
+     *
+     * @param key   键
+     * @param delta 步长
+     * @return 递增后的值
+     */
+    public long increment(String key, long delta) {
+        try {
+            Long result = redisTemplate.opsForValue().increment(key, delta);
+            return result != null ? result : 0L;
+        } catch (Exception e) {
+            log.error("Redis increment operation failed: key={}, delta={}, error={}",
+                    key, delta, e.getMessage(), e);
+            return 0L;
+        }
+    }
+
+    /**
+     * 原子递减
+     *
+     * @param key 键
+     * @return 递减后的值
+     */
+    public long decrement(String key) {
+        try {
+            Long result = redisTemplate.opsForValue().decrement(key);
+            return result != null ? result : 0L;
+        } catch (Exception e) {
+            log.error("Redis decrement operation failed: key={}, error={}", key, e.getMessage(), e);
+            return 0L;
+        }
+    }
+
+    /**
+     * 原子递减指定步长
+     *
+     * @param key   键
+     * @param delta 步长
+     * @return 递减后的值
+     */
+    public long decrement(String key, long delta) {
+        try {
+            Long result = redisTemplate.opsForValue().decrement(key, delta);
+            return result != null ? result : 0L;
+        } catch (Exception e) {
+            log.error("Redis decrement operation failed: key={}, delta={}, error={}",
+                    key, delta, e.getMessage(), e);
+            return 0L;
+        }
+    }
+
+    // ========== 批量操作 ==========
+
+    /**
+     * 批量获取
+     *
+     * @param keys 键列表
+     * @return 值列表
+     */
+    public List<Object> multiGet(Collection<String> keys) {
+        try {
+            if (CollectionUtils.isEmpty(keys)) {
+                return new ArrayList<>();
+            }
+            List<Object> values = redisTemplate.opsForValue().multiGet(keys);
+            return values != null ? values : new ArrayList<>();
+        } catch (Exception e) {
+            log.error("Redis multiGet operation failed: keys={}, error={}", keys, e.getMessage(), e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * 批量设置
+     *
+     * @param map 键值映射
+     * @return 是否成功
+     */
+    public boolean multiSet(Map<String, Object> map) {
+        try {
+            if (map == null || map.isEmpty()) {
+                return true;
+            }
+            redisTemplate.opsForValue().multiSet(map);
+            return true;
+        } catch (Exception e) {
+            log.error("Redis multiSet operation failed: error={}", e.getMessage(), e);
+            return false;
+        }
+    }
+
+    // ========== 工具方法 ==========
+
+    /**
+     * 根据模式获取键列表
+     *
+     * @param pattern 模式（支持通配符）
+     * @return 键列表
+     */
+    public Set<String> keys(String pattern) {
+        try {
+            Set<String> keys = redisTemplate.keys(pattern);
+            return keys != null ? keys : new HashSet<>();
+        } catch (Exception e) {
+            log.error("Redis keys operation failed: pattern={}, error={}", pattern, e.getMessage(), e);
+            return new HashSet<>();
+        }
+    }
+
+    /**
+     * 获取 RedisTemplate 实例（供高级操作使用）
+     *
+     * @return RedisTemplate 实例
+     */
+    public RedisTemplate<String, Object> getRedisTemplate() {
+        return redisTemplate;
+    }
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/user/Keys/UserKey.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/user/Keys/UserKey.java
@@ -1,0 +1,98 @@
+package com.kisesaki.blog.user.Keys;
+
+import com.kisesaki.blog.redis.BasePrefix;
+
+/**
+ * 用户相关的 Redis Key 前缀集合。
+ *
+ * 包含常用用户键：按ID缓存、会话、刷新令牌、登录尝试、验证码、设备列表、邮箱验证令牌等。
+ */
+public final class UserKey extends BasePrefix {
+
+    private UserKey(int expireSeconds, String prefix) {
+        super(expireSeconds, prefix);
+    }
+
+    // 按用户ID缓存用户信息（永久）
+    public static final UserKey BY_ID = new UserKey(0, "byId");
+
+    // 用户会话（7天）
+    public static final UserKey SESSION = new UserKey(60 * 60 * 24 * 7, "session");
+
+    // 设备刷新令牌（30天）
+    public static final UserKey DEVICE_REFRESH_TOKEN = new UserKey(60 * 60 * 24 * 30, "device:refreshToken");
+
+    // 用户设备集合（30天，与刷新令牌同期）
+    public static final UserKey USER_DEVICES = new UserKey(60 * 60 * 24 * 30, "devices");
+
+    // 设备令牌元数据（30天）
+    public static final UserKey DEVICE_TOKEN_METADATA = new UserKey(60 * 60 * 24 * 30, "device:metadata");
+
+    // 登录失败尝试计数（15分钟）
+    public static final UserKey LOGIN_ATTEMPT = new UserKey(60 * 15, "loginAttempt");
+
+    // 验证码（5分钟）
+    public static final UserKey VERIFICATION_CODE = new UserKey(60 * 5, "verifyCode");
+
+    // 邮箱验证（注册确认）令牌（24小时）
+    public static final UserKey EMAIL_VERIFICATION = new UserKey(60 * 60 * 24, "emailVerification");
+
+    // 用户已登录设备集合（永久）
+    public static final UserKey DEVICES = new UserKey(0, "devices");
+
+    // 密码重置令牌（1小时）
+    public static final UserKey PASSWORD_RESET = new UserKey(60 * 60, "passwordReset");
+
+    /**
+     * 拼接完整 Redis key，例如：
+     * UserKey.EMAIL_VERIFICATION.buildKey(token) ->
+     * "UserKey:emailVerification:abcdef..."
+     *
+     * @param parts 可变参数，按顺序追加到前缀后面，用 ':' 分隔
+     * @return 最终的 Redis key 字符串
+     */
+    public String buildKey(Object... parts) {
+        StringBuilder sb = new StringBuilder(getPrefix());
+        if (parts != null) {
+            for (Object p : parts) {
+                sb.append(':').append(String.valueOf(p));
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 构建设备刷新令牌的Redis键
+     * 格式：UserKey:device:refreshToken:username:deviceId
+     * 
+     * @param username 用户名
+     * @param deviceId 设备ID
+     * @return Redis键字符串
+     */
+    public static String buildDeviceRefreshTokenKey(String username, String deviceId) {
+        return DEVICE_REFRESH_TOKEN.buildKey(username, deviceId);
+    }
+
+    /**
+     * 构建用户设备集合的Redis键
+     * 格式：UserKey:devices:username
+     * 
+     * @param username 用户名
+     * @return Redis键字符串
+     */
+    public static String buildUserDevicesKey(String username) {
+        return USER_DEVICES.buildKey(username);
+    }
+
+    /**
+     * 构建设备元数据的Redis键
+     * 格式：UserKey:device:metadata:username:deviceId
+     * 
+     * @param username 用户名
+     * @param deviceId 设备ID
+     * @return Redis键字符串
+     */
+    public static String buildDeviceMetadataKey(String username, String deviceId) {
+        return DEVICE_TOKEN_METADATA.buildKey(username, deviceId);
+    }
+}


### PR DESCRIPTION
### **描述 (Description)**

本次 Pull Request 的主要目标：

- 为项目引入通用的 Redis 操作服务 `RedisService`，统一封装常用 Redis 操作。
- 增加 Redis Key 前缀接口及其基类实现，便于对不同业务模块的 Key 进行统一命名和管理。
- 添加用户相关的 Redis Key 前缀集合，作为示例和初始实现。

此改动涉及的模块：

- `backend/blog-backend/src/main/java/com/kisesaki/blog/redis`

---

### **主要变更 (Changes)**

- **新增**: `RedisService` 类，提供通用的 Redis 操作接口（get/set/expire/delete 等）。
- **新增**: Redis Key 前缀接口与基类实现（用于统一 Key 命名）。
- **新增**: 用户相关的 Redis Key 前缀集合实现。
- **修改**: 无其他模块修改（本次提交主要为新增功能）。
- **删除**: 无。
- **优化/重构**: 将 Redis 操作抽象为服务层，便于后续统一管理、注入与测试。

---

### **影响范围 (Impact)**

- 影响的功能/模块：后端 Redis 相关功能的初始化和调用处，如缓存、计数器等将在引入该服务后统一使用。
- 是否涉及数据库/接口/配置变更：需要在后端配置中确认 Redis 连接信息（如果尚未存在）。不修改数据库结构。
- 是否存在向下兼容性风险：向后兼容，新增服务不会破坏现有逻辑；但若切换已有直接访问 Redis 的代码到 `RedisService`，需注意 Key 命名一致性。
