### PR TITLE
✨ feat(backend.config): 添加前端 base-url 配置并类型绑定

### DIFF
--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/config/ApplicationProperties.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/config/ApplicationProperties.java
@@ -1,0 +1,26 @@
+package com.kisesaki.blog.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+/**
+ * 应用通用配置属性
+ *
+ * @author KiseSaki
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "kisesaki.blog")
+public class ApplicationProperties {
+
+    /* 前端应用配置 */
+    private Frontend frontend = new Frontend();
+
+    @Data
+    public static class Frontend {
+        // 前端基础URL
+        private String baseUrl;
+    }
+}

--- a/backend/blog-backend/src/main/resources/application-dev.yml
+++ b/backend/blog-backend/src/main/resources/application-dev.yml
@@ -119,6 +119,10 @@ kisesaki:
     jwt:
       secret: ${JWT_SECRET:kisesaki-blog-jwt-secret-key-for-development-only}
 
+    # 前端应用配置（开发环境）
+    frontend:
+      base-url: ${FRONTEND_BASE_URL:http://localhost:3000}
+
     # 设备指纹安全配置（开发环境）
     security:
       device:

--- a/backend/blog-backend/src/main/resources/application-prod.yml
+++ b/backend/blog-backend/src/main/resources/application-prod.yml
@@ -140,6 +140,10 @@ kisesaki:
     jwt:
       secret: ${JWT_SECRET}
 
+    # 前端应用配置（生产环境）
+    frontend:
+      base-url: ${FRONTEND_BASE_URL:http://localhost:3000}
+
     # 设备指纹安全配置（生产环境 - 增强安全性）
     security:
       device:

--- a/backend/blog-backend/src/main/resources/application.yml
+++ b/backend/blog-backend/src/main/resources/application.yml
@@ -112,6 +112,10 @@ kisesaki:
       expiration: 86400000 # 24小时 (毫秒)
       refresh-expiration: 604800000 # 7天 (毫秒)
 
+    # 前端应用配置
+    frontend:
+      base-url: ${FRONTEND_BASE_URL:http://localhost:3000}
+
     # 设备指纹安全配置
     security:
       device:


### PR DESCRIPTION
### **描述 (Description)**

本次 Pull Request 的主要目标：

- 将前端应用的 base URL 提取为可配置项，便于不同环境下配置前端入口地址
- 提供类型安全的配置绑定，便于在代码中注入并使用前端 base URL（例如邮件模板、重定向链接）

此改动涉及的模块：

- `backend/blog-backend/src/main/resources`
- `backend/blog-backend/src/main/java/com/kisesaki/blog/config`

---

### **主要变更 (Changes)**

- **新增**: `com.kisesaki.blog.config.ApplicationProperties`（类型安全的配置绑定类，包含 `frontend.baseUrl`）
- **修改**: `application.yml`、`application-dev.yml`、`application-prod.yml`（新增 `kisesaki.blog.frontend.base-url` 配置）
- **删除**: 无
- **优化/重构**: 将前端 base URL 从硬编码/散落位置集中为统一配置，提升可维护性与环境可配置性

---

### **影响范围 (Impact)**

- 影响的功能/模块：后端对前端 URL 的引用点（邮件/模板/需要生成前端链接的接口）
- 是否涉及数据库/接口/配置变更：涉及后端配置（application*.yml），不涉及数据库或外部 API 结构变更
- 是否存在向下兼容性风险：低，新增配置为可选并有默认值，现有逻辑若直接读取新配置字段可能需要小幅调整，但不会破坏向下兼容性
