### PR TITLE
✨ feat(auth): 增强密码重置与修改流程并完善邮件事件工厂

### DIFF
--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/AuthController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/AuthController.java
@@ -117,6 +117,22 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("forgot-password")
+    @Operation(summary = "忘记密码", description = "用户通过邮箱重置登录密码")
+    public ResponseEntity<ApiResponse<String>> forgotPassword(
+            @Valid @RequestBody ForgotPasswordRequestDto forgotPasswordRequestDto) {
+        ApiResponse<String> response = authService.forgotPassword(forgotPasswordRequestDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/reset-password")
+    @Operation(summary = "确认重置密码", description = "用户通过邮箱收到的令牌确认重置密码")
+    public ResponseEntity<ApiResponse<String>> resetPassword(
+            @Valid @RequestBody ResetPasswordRequestDto resetPasswordRequest) {
+        ApiResponse<String> response = authService.resetPassword(resetPasswordRequest);
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping("/clean-expired")
     @Operation(summary = "清理过期令牌", description = "清理用户的过期令牌")
     public ResponseEntity<ApiResponse<String>> cleanExpiredTokens(

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/AuthController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/AuthController.java
@@ -106,6 +106,17 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("change-password")
+    @Operation(summary = "修改密码", description = "用户修改自己的登录密码")
+    public ResponseEntity<ApiResponse<String>> changePassword(
+            @Valid @RequestBody ChangePasswordRequestDto changePasswordRequest,
+            Authentication authentication,
+            HttpServletRequest request) {
+        String username = authentication.getName();
+        ApiResponse<String> response = authService.changePassword(username, changePasswordRequest, request);
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping("/clean-expired")
     @Operation(summary = "清理过期令牌", description = "清理用户的过期令牌")
     public ResponseEntity<ApiResponse<String>> cleanExpiredTokens(

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/AuthService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/AuthService.java
@@ -1,12 +1,9 @@
 package com.kisesaki.blog.auth;
 
-import java.util.HashMap;
+import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.UUID;
+import java.util.Optional;
 
-import com.kisesaki.blog.auth.dto.request.VerifyEmailRequestDto;
-import com.kisesaki.blog.auth.event.UserRegistrationEvent;
-import com.kisesaki.blog.redis.RedisService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -19,10 +16,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kisesaki.blog.auth.dto.DeviceInfo;
+import com.kisesaki.blog.auth.dto.request.ChangePasswordRequestDto;
 import com.kisesaki.blog.auth.dto.request.LoginRequestDto;
 import com.kisesaki.blog.auth.dto.request.RefreshTokenRequestDto;
 import com.kisesaki.blog.auth.dto.request.RegisterRequestDto;
+import com.kisesaki.blog.auth.dto.request.VerifyEmailRequestDto;
 import com.kisesaki.blog.auth.dto.response.LoginResponseDto;
+import com.kisesaki.blog.auth.event.UserRegistrationEvent;
 import com.kisesaki.blog.auth.security.jwt.DeviceFingerprintService;
 import com.kisesaki.blog.auth.security.jwt.JwtTokenProvider;
 import com.kisesaki.blog.auth.security.jwt.RefreshTokenService;
@@ -31,6 +31,7 @@ import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.enums.ErrorCode;
 import com.kisesaki.blog.common.exception.BusinessException;
 import com.kisesaki.blog.notification.event.EmailEventPublisher;
+import com.kisesaki.blog.redis.RedisService;
 import com.kisesaki.blog.user.Keys.UserKey;
 import com.kisesaki.blog.user.entity.User;
 import com.kisesaki.blog.user.mapper.UserMapper;
@@ -59,6 +60,7 @@ public class AuthService {
     private final ApplicationEventPublisher eventPublisher;
     private final RedisService RedisService;
     private final RedisService redisService;
+    private final EmailEventPublisher emailEventPublisher;
 
     @Value("${kisesaki.blog.jwt.expiration}")
     private Long jwtExpiration;
@@ -176,8 +178,7 @@ public class AuthService {
                     user.getId(),
                     user.getUsername(),
                     user.getEmail(),
-                    java.time.LocalDateTime.now()
-            );
+                    LocalDateTime.now());
             eventPublisher.publishEvent(event);
             log.info("用户 {} 注册完成，ID: {}", user.getUsername(), user.getId());
             return ApiResponse.success("注册成功", user.getId().toString());
@@ -364,6 +365,57 @@ public class AuthService {
         } catch (Exception e) {
             log.error("获取用户 {} 设备列表失败", username, e);
             return ApiResponse.error("获取设备列表失败");
+        }
+    }
+
+    /**
+     * 修改密码
+     *
+     * @param changePasswordRequestDto 修改密码请求
+     * @param request                  HTTP请求对象，用于设备指纹验证
+     * @return 修改结果
+     */
+    public ApiResponse<String> changePassword(String username, ChangePasswordRequestDto changePasswordRequestDto, HttpServletRequest request) {
+        String oldPassword = changePasswordRequestDto.getOldPassword();
+        String newPassword = changePasswordRequestDto.getNewPassword();
+
+        if (oldPassword.equals(newPassword)) {
+            return ApiResponse.error("新密码不能与旧密码相同");
+        }
+
+        Optional<User> user = userMapper.findByUsername(username);
+        if (user.isEmpty()) {
+            return ApiResponse.error("用户不存在");
+        }
+
+        if (!user.get().getEmailVerified()) {
+            return ApiResponse.error("请先验证邮箱");
+        }
+
+        if (!passwordEncoder.matches(oldPassword, user.get().getPassword())) {
+            return ApiResponse.error("旧密码不正确");
+        }
+
+        user.get().setPassword(passwordEncoder.encode(newPassword));
+        try {
+            userMapper.updateById(user.get());
+
+            // 修改密码后，删除所有刷新令牌，强制重新登录
+            refreshTokenService.deleteAllRefreshTokens(username);
+            // 发送密码修改通知邮件
+            emailEventPublisher.publishPasswordChangedEvent(
+                    user.get().getEmail(),
+                    user.get().getId(),
+                    user.get().getUsername(),
+                    String.valueOf(LocalDateTime.now()),
+                    request.getRemoteAddr()
+            );
+
+            log.info("用户 {} 修改密码成功", username);
+            return ApiResponse.success("密码修改成功");
+        } catch (Exception e) {
+            log.error("用户 {} 修改密码失败", username, e);
+            return ApiResponse.error("密码修改失败");
         }
     }
 

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/AuthService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/AuthService.java
@@ -3,7 +3,10 @@ package com.kisesaki.blog.auth;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
+import com.kisesaki.blog.auth.dto.request.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -16,11 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kisesaki.blog.auth.dto.DeviceInfo;
-import com.kisesaki.blog.auth.dto.request.ChangePasswordRequestDto;
-import com.kisesaki.blog.auth.dto.request.LoginRequestDto;
-import com.kisesaki.blog.auth.dto.request.RefreshTokenRequestDto;
-import com.kisesaki.blog.auth.dto.request.RegisterRequestDto;
-import com.kisesaki.blog.auth.dto.request.VerifyEmailRequestDto;
 import com.kisesaki.blog.auth.dto.response.LoginResponseDto;
 import com.kisesaki.blog.auth.event.UserRegistrationEvent;
 import com.kisesaki.blog.auth.security.jwt.DeviceFingerprintService;
@@ -358,9 +356,9 @@ public class AuthService {
      * @param username 用户名
      * @return 设备ID集合
      */
-    public ApiResponse<java.util.Set<String>> getUserDevices(String username) {
+    public ApiResponse<Set<String>> getUserDevices(String username) {
         try {
-            java.util.Set<String> devices = refreshTokenService.getUserDevices(username);
+            Set<String> devices = refreshTokenService.getUserDevices(username);
             return ApiResponse.success("获取设备列表成功", devices);
         } catch (Exception e) {
             log.error("获取用户 {} 设备列表失败", username, e);
@@ -416,6 +414,93 @@ public class AuthService {
         } catch (Exception e) {
             log.error("用户 {} 修改密码失败", username, e);
             return ApiResponse.error("密码修改失败");
+        }
+    }
+
+    /**
+     * 忘记密码，发送重置邮件
+     *
+     * @param forgotPasswordRequestDto 重置密码请求
+     * @return 重置结果
+     */
+    public ApiResponse<String> forgotPassword(ForgotPasswordRequestDto forgotPasswordRequestDto) {
+        String email = forgotPasswordRequestDto.getEmail();
+        Optional<User> userOpt = userMapper.findByEmail(email);
+        if (userOpt.isEmpty()) {
+            log.warn("密码重置请求失败，邮箱未注册：{}", email);
+            return ApiResponse.error("邮箱未注册");
+        }
+
+        User user = userOpt.get();
+        if (!user.getEmailVerified()) {
+            log.warn("密码重置请求失败，用户邮箱未验证：{}", email);
+            return ApiResponse.error("请先验证邮箱");
+        }
+
+        try {
+            // 生成密码重置令牌并发送邮件
+            String resetToken = UUID.randomUUID().toString();
+            String redisKey = UserKey.buildPasswordResetKey(resetToken);
+            RedisService.hSet(redisKey, "userId", user.getId());
+            RedisService.expire(redisKey, 15 * 60); // 15分钟过期
+
+            emailEventPublisher.publishPasswordResetEvent(
+                    user.getEmail(),
+                    user.getId(),
+                    user.getUsername(),
+                    resetToken
+            );
+
+            log.info("密码重置邮件已发送至：{}", email);
+            return ApiResponse.success("密码重置邮件已发送，请检查您的邮箱");
+        } catch (Exception e) {
+            log.error("发送密码重置邮件失败，邮箱：{}", email, e);
+            return ApiResponse.error("发送密码重置邮件失败，请稍后重试");
+        }
+    }
+
+    /**
+     * 验证密码重置令牌并设置新密码
+     *
+     * @param resetPasswordRequestDto 重置密码请求
+     * @return 重置结果
+     */
+    public ApiResponse<String> resetPassword(ResetPasswordRequestDto resetPasswordRequestDto) {
+        String resetToken = resetPasswordRequestDto.getResetToken();
+        String newPassword = resetPasswordRequestDto.getNewPassword();
+        String redisKey = UserKey.buildPasswordResetKey(resetToken);
+
+        Map<Object, Object> resetData = redisService.hGetAll(redisKey);
+        if (resetData == null || resetData.isEmpty()) {
+            log.warn("密码重置失败，令牌无效或已过期，令牌: {}", resetToken);
+            return ApiResponse.error("密码重置令牌无效或已过期");
+        }
+
+        Long userId = (Long) resetData.get("userId");
+        Optional<User> userOpt = userMapper.findById(userId);
+        if (userOpt.isEmpty()) {
+            log.error("密码重置失败，用户不存在，用户ID: {}", userId);
+            return ApiResponse.error("用户不存在");
+        }
+
+        User user = userOpt.get();
+        if (passwordEncoder.matches(newPassword, user.getPassword())) {
+            return ApiResponse.error("新密码不能与旧密码相同");
+        }
+
+        user.setPassword(passwordEncoder.encode(newPassword));
+        try {
+            userMapper.updateById(user);
+            // 删除整个key
+            redisService.delete(redisKey);
+            // 重置密码后，删除所有刷新令牌，强制重新登录
+            refreshTokenService.deleteAllRefreshTokens(user.getUsername());
+
+            log.info("用户 {} 的密码重置成功", user.getUsername());
+            return ApiResponse.success("密码重置成功");
+        } catch (Exception e) {
+            log.error("用户 {} 的密码重置失败", user.getUsername(), e);
+            return ApiResponse.error("密码重置失败，请稍后重试");
         }
     }
 

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/request/ChangePasswordRequestDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/request/ChangePasswordRequestDto.java
@@ -1,0 +1,17 @@
+package com.kisesaki.blog.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ChangePasswordRequestDto {
+    @NotBlank(message = "旧密码不能为空")
+    private String oldPassword;
+
+    @NotBlank(message = "新密码不能为空")
+    @Size(min = 6, max = 100, message = "密码长度必须在6-100字符之间")
+    private String newPassword;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/request/ForgotPasswordRequestDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/request/ForgotPasswordRequestDto.java
@@ -1,0 +1,15 @@
+package com.kisesaki.blog.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ForgotPasswordRequestDto {
+
+    @NotBlank(message = "电子邮箱不能为空")
+    @Email(message = "电子邮箱格式不正确")
+    private String email;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/request/ResetPasswordRequestDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/request/ResetPasswordRequestDto.java
@@ -1,0 +1,17 @@
+package com.kisesaki.blog.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ResetPasswordRequestDto {
+    @NotBlank(message = "邮箱验证令牌不能为空")
+    private String resetToken;
+
+    @NotBlank(message = "新密码不能为空")
+    @Size(min = 6, max = 100, message = "密码长度必须在6-100字符之间")
+    private String newPassword;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/notification/event/EmailEventFactory.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/notification/event/EmailEventFactory.java
@@ -68,7 +68,7 @@ public class EmailEventFactory {
 
         return new EmailEvent(source, EmailType.PASSWORD_RESET, toEmail, userId, userDisplayName,
                 variables, "密码重置请求 - KiseSaki博客",
-                "PASSWORD_RESET", userId.toString(), 3); // 密码重置，优先级普通
+                "PASSWORD_RESET", userId.toString(), 2); // 密码重置，优先级较高
     }
 
     /**

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/notification/event/EmailEventFactory.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/notification/event/EmailEventFactory.java
@@ -68,7 +68,7 @@ public class EmailEventFactory {
 
         return new EmailEvent(source, EmailType.PASSWORD_RESET, toEmail, userId, userDisplayName,
                 variables, "密码重置请求 - KiseSaki博客",
-                "PASSWORD_RESET", userId.toString(), 1); // 密码重置，优先级最高
+                "PASSWORD_RESET", userId.toString(), 3); // 密码重置，优先级普通
     }
 
     /**
@@ -187,7 +187,7 @@ public class EmailEventFactory {
 
         return new EmailEvent(source, EmailType.WELCOME, toEmail, userId, userDisplayName,
                 variables, "欢迎加入KiseSaki博客！",
-                "USER_WELCOME", userId.toString(), 3); // 欢迎邮件，普通优先级
+                "USER_WELCOME", userId.toString(), 3); // 欢迎邮件，优先级普通
     }
 
     /**
@@ -211,7 +211,7 @@ public class EmailEventFactory {
 
         return new EmailEvent(source, EmailType.PASSWORD_CHANGED, toEmail, userId, userDisplayName,
                 variables, "密码修改通知 - KiseSaki博客",
-                "PASSWORD_CHANGED", userId.toString(), 1); // 密码修改，优先级最高
+                "PASSWORD_CHANGED", userId.toString(), 3); // 密码修改，优先级普通
     }
 
     /**
@@ -360,7 +360,7 @@ public class EmailEventFactory {
 
         return new EmailEvent(source, EmailType.CONTENT_MODERATION, moderatorEmail, moderatorId, moderatorName,
                 variables, "内容审核通知 - " + contentTitle,
-                "CONTENT_MODERATION", contentId.toString(), 2); // 内容审核，优先级较高
+                "CONTENT_MODERATION", contentId.toString(), 3); // 内容审核，优先级普通
     }
 
     /**

--- a/backend/blog-backend/src/main/resources/templates/email/auth/password-changed.html
+++ b/backend/blog-backend/src/main/resources/templates/email/auth/password-changed.html
@@ -113,7 +113,7 @@
         </div>
         
         <div class="content">
-            <p>您好 <strong>${userName}</strong>，</p>
+            <p>您好 <strong>${userDisplayName}</strong>，</p>
             
             <div class="success-box">
                 <h3 style="margin-top: 0; font-size: 20px;">🎉 密码已成功更新</h3>
@@ -134,7 +134,7 @@
                 </div>
                 <div class="info-row">
                     <span class="label">账户邮箱：</span>
-                    <span class="value">${userName}的邮箱</span>
+                    <span class="value">${userDisplayName}的邮箱</span>
                 </div>
                 <div class="info-row">
                     <span class="label">操作类型：</span>

--- a/backend/blog-backend/src/main/resources/templates/email/auth/password-reset.html
+++ b/backend/blog-backend/src/main/resources/templates/email/auth/password-reset.html
@@ -118,7 +118,7 @@
         </div>
         
         <div class="content">
-            <p>您好 <strong>${userName}</strong>，</p>
+            <p>您好 <strong>${userDisplayName}</strong>，</p>
             
             <p>我们收到了您的密码重置请求。如果这是您本人的操作，请点击下方按钮重置密码。</p>
             


### PR DESCRIPTION
### **描述 (Description)**

本次 Pull Request 的主要目标：

- 增加用户忘记密码 / 重置密码以及修改密码的请求与处理逻辑。
- 在通知子系统中扩展/重构邮件事件工厂以支持密码重置与密码修改通知模板。

此改动涉及的模块：

- `backend/blog-backend/src/main/java/com/kisesaki/blog/auth`（控制器、服务、DTO）
- `backend/blog-backend/src/main/java/com/kisesaki/blog/notification/event`（EmailEventFactory）
- `backend/blog-backend/src/main/resources/templates/email/auth`（邮件模板）

---

### **主要变更 (Changes)**

- **新增**: `ChangePasswordRequestDto`, `ForgotPasswordRequestDto`, `ResetPasswordRequestDto`（请求 DTO）
- **新增**: 在 `AuthController` 添加 `forgot-password`、`/reset-password`、`change-password` 等接口路由（若为新增或暴露行为）。
- **修改**: `AuthService` 增加 `forgotPassword` 与 `resetPassword`、`changePassword` 的实现逻辑，包含 Redis 密码重置 key 的存储与校验、刷新令牌的清理、以及通过 `EmailEventPublisher` 发布相应邮件事件。
- **修改**: `EmailEventFactory` 新增/完善 `createPasswordResetEvent` 与 `createPasswordChangedEvent`，并统一邮件变量（如 `resetUrl`、`expireMinutes`、`changeTime`、`ipAddress` 等）。
- **新增/修改**: 邮件模板 `password-reset.html` 与 `password-changed.html`（添加符合前端地址链接与变量占位的 HTML 模板）。

---

### **影响范围 (Impact)**

- 影响的功能/模块：用户认证与账户安全相关 API（忘记密码、重置密码、修改密码）、邮件通知子系统与模板。
- 是否涉及数据库/接口/配置变更：
  - 使用 Redis 存储密码重置令牌（已使用现有 `UserKey.buildPasswordResetKey` 约定），需确保 Redis 可用与过期策略（当前代码设置 15 分钟）。
  - 前端重置链接使用 `applicationProperties.frontend.baseUrl` 构建，需确保对应配置在各环境中正确。
- 是否存在向下兼容性风险：
  - 向后兼容性：对现有登录/注册流程无侵入性破坏；新增 API 路由（`forgot-password`、`/reset-password`、`change-password`）为增加功能，但需在 API 文档中标注。
  - 若外部系统依赖邮件事件的类型或变量名，要注意 `EmailEventFactory` 中新增变量键（如 `resetUrl`、`expireMinutes`、`changeTime`、`ipAddress`）可能影响消费者，需评估消费端（如邮件发送服务或模板渲染）兼容性。
