### PR TITLE
📝 docs(frontend): 更新UI库架构文档，添加双UI库设计方案

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ applyTo: "**"
 
 **核心技术栈:**
 
-- 前端: React, TypeScript, Vite, TailWindCSS, shadcn/ui, pnpm
+- 前端: React, TypeScript, Vite, TailWindCSS, shadcn/ui (前台), Ant Design (后台管理), pnpm
 - 后端: Java, Spring Boot 3, Maven, PostgreSQL, MyBatis-Plus, Spring Security & JWT, Redis, Kafka
 - 状态管理: 优先使用 Zustand 进行全局状态管理。
 - 部署：Docker + Kubernetes + Github Actions。
@@ -15,17 +15,25 @@ applyTo: "**"
 **前端核心架构原则:**
 
 1. **结构**: 严格遵循我提供的目录结构 (`api/`, `components/`, `hooks/`, `pages/` 等)。应预留 `lib/` 用于工具函数、`config/` 用于常量和全局配置，`stores/` 用于 Zustand 状态。
-2. **组件化**: 遵循原子设计理念。`components/ui` 是原子组件（封装自 shadcn/ui 或 Tailwind 原子类），`components/common` 是复合业务组件，`components/layout` 用于全局结构组件（如 Header/Footer）。
-3. **类型安全**: 必须使用严格的 TypeScript，**禁用 any（通过 tsconfig 限制）**。所有后端接口响应、DTO 定义应集中在 `src/types/api.ts` 等文件中维护。
-4. **API 调用**: 所有后端 API 请求都必须通过 `src/api/` 目录下的服务函数进行封装，避免在组件中直接使用 axios/fetch。封装应内置统一错误处理、loading 状态处理。
-5. **状态管理**: 全局状态使用 Zustand。每个功能模块单独定义 Store 文件，并通过 selector 优化性能。全局登录用户状态、权限、菜单等应集中在 `authStore` 管理。
-6. **路由权限控制**: 页面级权限控制必须通过全局 `PrivateRoute` 组件封装，结合 Zustand 中的 `user.roles[]` 判断权限，支持嵌套路由拦截与重定向。
-7. **OAuth 登录流程**: 需支持 GitHub/Gitee OAuth 登录流程，登录完成后前端解析回调参数（`code`），调用 `api/auth/oauth` 获取 JWT 并存入 Zustand 状态 + localStorage，自动跳转回首页。
-8. **样式设计**: 使用 TailwindCSS 原子类设计 UI，优先复用 shadcn/ui 组件库。如需扩展样式，建议写入 `src/styles/utilities.css`，不得写入全局样式覆盖。
-9. **错误处理**: API 层必须内置错误提示逻辑，默认使用 `toast`（来自 shadcn/toaster）展示错误信息。可为严重错误（如 403, 500）定义全局错误边界组件。
-10. **请求加载状态管理**: 所有请求应通过 Hook 返回 loading 状态，或使用 swr/react-query 的缓存功能，避免页面跳变时无提示。
-11. **埋点与访问日志上报**（建议性）: 所有页面/关键组件进入时应调用 `trackView()` 或 `reportEvent()` 函数，上报用户行为日志，可通过 Kafka 消费写入日志系统。
-12. **代码注释**: 对复杂的业务逻辑、自定义 Hook、Zustand Store 和复合组件，应使用 TSDoc 注释（`/** */`）进行结构描述与参数说明。
+2. **双 UI 库架构**:
+   - **前台博客**: 使用 `shadcn/ui + TailwindCSS`，注重用户阅读体验和视觉美观
+   - **后台管理**: 使用 `Ant Design (antd)`，提供专业的企业级管理界面
+3. **组件化**: 遵循原子设计理念。`components/ui` 是原子组件（前台封装自 shadcn/ui，后台使用 antd 组件），`components/common` 是复合业务组件，`components/layout` 用于全局结构组件（如 Header/Footer）。
+4. **类型安全**: 必须使用严格的 TypeScript，**禁用 any（通过 tsconfig 限制）**。所有后端接口响应、DTO 定义应集中在 `src/types/api.ts` 等文件中维护。
+5. **API 调用**: 所有后端 API 请求都必须通过 `src/api/` 目录下的服务函数进行封装，避免在组件中直接使用 axios/fetch。封装应内置统一错误处理、loading 状态处理。
+6. **状态管理**: 全局状态使用 Zustand。每个功能模块单独定义 Store 文件，并通过 selector 优化性能。全局登录用户状态、权限、菜单等应集中在 `authStore` 管理。
+7. **路由权限控制**: 页面级权限控制必须通过全局 `PrivateRoute` 组件封装，结合 Zustand 中的 `user.roles[]` 判断权限，支持嵌套路由拦截与重定向。
+8. **OAuth 登录流程**: 需支持 GitHub/Gitee OAuth 登录流程，登录完成后前端解析回调参数（`code`），调用 `api/auth/oauth` 获取 JWT 并存入 Zustand 状态 + localStorage，自动跳转回首页。
+9. **样式设计**:
+   - **前台**: 使用 TailwindCSS 原子类设计 UI，优先复用 shadcn/ui 组件库
+   - **后台**: 使用 Ant Design 组件库，保持企业级管理界面风格
+   - 如需扩展样式，建议写入 `src/styles/utilities.css`，不得写入全局样式覆盖
+10. **错误处理**:
+    - **前台**: API 层内置错误提示逻辑，默认使用 `toast`（来自 shadcn/toaster）展示错误信息
+    - **后台**: 使用 Ant Design 的 `message` 或 `notification` 组件展示错误信息
+11. **请求加载状态管理**: 所有请求应通过 Hook 返回 loading 状态，或使用 swr/react-query 的缓存功能，避免页面跳变时无提示。
+12. **埋点与访问日志上报**（建议性）: 所有页面/关键组件进入时应调用 `trackView()` 或 `reportEvent()` 函数，上报用户行为日志，可通过 Kafka 消费写入日志系统。
+13. **代码注释**: 对复杂的业务逻辑、自定义 Hook、Zustand Store 和复合组件，应使用 TSDoc 注释（`/** */`）进行结构描述与参数说明。
 
 **后端核心架构原则:**
 

--- a/.github/prompts/frontend-project-task.md
+++ b/.github/prompts/frontend-project-task.md
@@ -1,5 +1,18 @@
 # 🎯 前端项目开发任务流 (KiseSaki Blog)
 
+## 🎨 **UI 设计策略**
+> **双 UI 库架构设计理念**
+
+- **🌟 前台博客 (Blog Frontend)**: 使用 **shadcn/ui + TailwindCSS**
+  - 注重用户阅读体验和视觉美观
+  - 现代化的组件设计，支持深度定制
+  - 轻量级，加载性能优先
+  
+- **👑 后台管理 (Admin Dashboard)**: 使用 **Ant Design (antd)**
+  - 专业的企业级管理界面
+  - 丰富的表格、表单、图表组件
+  - 成熟的交互模式，提升管理效率
+
 ## 🚀 阶段一：项目基础架构 (Foundation)
 
 ### ✅ **1. 项目初始化与配置**
@@ -7,7 +20,7 @@
 
 * **📦 依赖安装**:
   * [X] 核心依赖: `react`, `react-dom`, `typescript`, `vite`
-  * [X] UI 库: `tailwindcss`, `@tailwindcss/typography`, `shadcn/ui`
+  * [X] UI 库: `tailwindcss`, `@tailwindcss/typography`, `shadcn/ui` (前台), `antd` (后台管理)
   * [X] 状态管理: `zustand`
   * [X] 路由: `react-router-dom`
   * [X] HTTP 客户端: `axios`
@@ -123,6 +136,7 @@
 ---
 
 ## 📝 阶段三：博客核心功能 (Blog Core)
+> **UI 库**: 使用 **shadcn/ui + TailwindCSS** 构建用户友好的前台界面
 
 ### 🚧 **7. 博客 API 服务层**
 
@@ -144,30 +158,30 @@
   * [ ] `getCategories()` - 获取所有分类
   * [ ] `getTags()` - 获取所有标签
 
-### � **8. 博客展示组件**
+### � **8. 博客展示组件 (基于 shadcn/ui)**
 
 * **📰 文章卡片** (`src/components/blog/PostCard.tsx`):
-  * [ ] 文章标题、摘要、封面图显示
-  * [ ] 发布时间、作者、分类、标签
+  * [ ] 文章标题、摘要、封面图显示 (shadcn/ui Card 组件)
+  * [ ] 发布时间、作者、分类、标签 (shadcn/ui Badge 组件)
   * [ ] 阅读量、点赞数、评论数
   * [ ] 响应式卡片设计
 
 * **📋 文章列表** (`src/components/blog/PostList.tsx`):
   * [ ] 文章卡片网格布局
-  * [ ] 分页加载功能
-  * [ ] 加载状态和空状态处理
+  * [ ] 分页加载功能 (shadcn/ui Pagination 组件)
+  * [ ] 加载状态和空状态处理 (shadcn/ui Skeleton)
   * [ ] 列表/网格视图切换
 
 * **🏷️ 标签云** (`src/components/blog/TagCloud.tsx`):
-  * [ ] 标签权重可视化
+  * [ ] 标签权重可视化 (shadcn/ui Badge 组件)
   * [ ] 标签点击筛选功能
   * [ ] 响应式标签布局
 
 * **💬 评论组件** (`src/components/blog/Comment.tsx`):
-  * [ ] 评论列表展示
+  * [ ] 评论列表展示 (shadcn/ui Card 组件)
   * [ ] 嵌套回复支持
-  * [ ] 评论表单和提交
-  * [ ] 评论点赞和举报
+  * [ ] 评论表单和提交 (shadcn/ui Form + Input 组件)
+  * [ ] 评论点赞和举报 (shadcn/ui Button 组件)
 
 ### 🚧 **9. 博客页面组件**
 
@@ -268,6 +282,7 @@
 ---
 
 ## 👑 阶段五：管理员功能 (Admin Features)
+> **UI 库**: 使用 **Ant Design (antd)** 构建专业的管理后台界面
 
 ### 🚧 **14. 管理员 API 服务**
 
@@ -281,41 +296,48 @@
   * [ ] `manageCategories()` - 分类管理
   * [ ] `manageTags()` - 标签管理
 
-### 🚧 **15. 管理员组件**
+### 🚧 **15. 管理员组件 (基于 Ant Design)**
 
 * **✏️ 文章编辑器** (`src/components/admin/PostEditor.tsx`):
+  * [ ] 富文本编辑器集成 (使用 antd 的 Input 组件)
   * [ ] Markdown 编辑器集成
   * [ ] 实时预览功能
-  * [ ] 图片上传和管理
-  * [ ] 文章元数据编辑
+  * [ ] 图片上传和管理 (antd Upload 组件)
+  * [ ] 文章元数据编辑 (antd Form 组件)
 
 * **📊 统计图表** (`src/components/admin/StatChart.tsx`):
-  * [ ] 访问量统计图表
+  * [ ] 访问量统计图表 (结合 antd + ECharts/Chart.js)
   * [ ] 用户增长图表
   * [ ] 文章发布统计
 
-### 🚧 **16. 管理员页面**
+* **📝 数据表格** (`src/components/admin/DataTable.tsx`):
+  * [ ] 基于 antd Table 组件的通用数据表格
+  * [ ] 支持排序、筛选、分页
+  * [ ] 批量操作功能
+
+### 🚧 **16. 管理员页面 (Ant Design Layout)**
 
 * **📊 管理员仪表板** (`src/pages/Admin/AdminDashboard.tsx`):
-  * [ ] 网站统计概览
-  * [ ] 最新活动动态
-  * [ ] 快捷操作入口
+  * [ ] antd Layout 布局系统
+  * [ ] 网站统计概览 (antd Card + Statistic 组件)
+  * [ ] 最新活动动态 (antd Timeline 组件)
+  * [ ] 快捷操作入口 (antd Button 组件)
 
-* **📝 内容管理**:
-  * [ ] `PostManagement.tsx` - 文章管理
-  * [ ] `CategoryManagement.tsx` - 分类管理
-  * [ ] `TagManagement.tsx` - 标签管理
-  * [ ] `CommentManagement.tsx` - 评论管理
+* **📝 内容管理** (全部使用 antd 组件):
+  * [ ] `PostManagement.tsx` - 文章管理 (Table + Modal + Form)
+  * [ ] `CategoryManagement.tsx` - 分类管理 (Tree + Form)
+  * [ ] `TagManagement.tsx` - 标签管理 (Tag + Form)
+  * [ ] `CommentManagement.tsx` - 评论管理 (Table + Popconfirm)
 
 * **👥 用户管理** (`src/pages/Admin/UserManagement.tsx`):
-  * [ ] 用户列表和搜索
-  * [ ] 用户权限管理
-  * [ ] 用户状态控制
+  * [ ] 用户列表和搜索 (antd Table + Input.Search)
+  * [ ] 用户权限管理 (antd Select + Switch)
+  * [ ] 用户状态控制 (antd Badge + Button)
 
 * **⚙️ 系统设置** (`src/pages/Admin/SettingsPage.tsx`):
-  * [ ] 网站基本设置
-  * [ ] SEO 配置
-  * [ ] 系统维护选项
+  * [ ] 网站基本设置 (antd Form + Input/TextArea)
+  * [ ] SEO 配置 (antd Tabs + Form)
+  * [ ] 系统维护选项 (antd Switch + DatePicker)
 
 ---
 
@@ -441,7 +463,8 @@
 - 🔷 严格遵循 TypeScript 类型安全，禁用 `any`
 - 📝 关键组件和函数需要添加 TSDoc 注释
 - 🧪 核心功能需要编写单元测试
-- 🎨 遵循 Tailwind + shadcn/ui 设计规范
+- 🎨 **前台组件**: 遵循 TailwindCSS + shadcn/ui 设计规范
+- 👑 **后台组件**: 使用 Ant Design 组件库，保持企业级管理界面风格
 - 📊 重要页面和操作需要添加埋点跟踪
 
 ### 🔄 **持续改进**

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 ### 前端
 - React 18 + TypeScript
 - Vite 构建工具
-- TailwindCSS + shadcn/ui 组件库
+- TailwindCSS + shadcn/ui (前台博客界面)
+- Ant Design (后台管理界面)
 - Zustand 状态管理
 - React Router 路由管理
 


### PR DESCRIPTION
详细描述：
- 在项目文档中明确前台使用shadcn/ui，后台使用Ant Design的设计策略
- 更新.github/copilot-instructions.md，添加双UI库架构原则
- 更新frontend-project-task.md，为管理员功能模块添加Ant Design组件说明
- 更新README.md，在技术栈中说明UI库使用场景
- 强调前台注重用户体验，后台注重管理效率的设计理念

影响范围：
- .github/copilot-instructions.md - 核心架构原则更新
- .github/prompts/frontend-project-task.md - 前端开发任务流程更新
- README.md - 项目技术栈说明更新