### PR TITLE
✨ feat(theme): 添加主题切换功能和主题提供者组件

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ant-design/icons": "^6.0.0",
     "@tailwindcss/vite": "^4.1.11",
     "antd": "^5.27.1",
     "axios": "^1.10.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ant-design/icons':
+        specifier: ^6.0.0
+        version: 6.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tailwindcss/vite':
         specifier: ^4.1.11
         version: 4.1.11(vite@7.0.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1))
@@ -100,6 +103,9 @@ packages:
   '@ant-design/colors@7.2.1':
     resolution: {integrity: sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==}
 
+  '@ant-design/colors@8.0.0':
+    resolution: {integrity: sha512-6YzkKCw30EI/E9kHOIXsQDHmMvTllT8STzjMb4K2qzit33RW2pqCJP0sk+hidBntXxE+Vz4n1+RvCTfBw6OErw==}
+
   '@ant-design/cssinjs-utils@1.1.3':
     resolution: {integrity: sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==}
     peerDependencies:
@@ -116,11 +122,22 @@ packages:
     resolution: {integrity: sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==}
     engines: {node: '>=8.x'}
 
+  '@ant-design/fast-color@3.0.0':
+    resolution: {integrity: sha512-eqvpP7xEDm2S7dUzl5srEQCBTXZMmY3ekf97zI+M2DHOYyKdJGH0qua0JACHTqbkRnD/KHFQP9J1uMJ/XWVzzA==}
+    engines: {node: '>=8.x'}
+
   '@ant-design/icons-svg@4.4.2':
     resolution: {integrity: sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==}
 
   '@ant-design/icons@5.6.1':
     resolution: {integrity: sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+
+  '@ant-design/icons@6.0.0':
+    resolution: {integrity: sha512-o0aCCAlHc1o4CQcapAwWzHeaW2x9F49g7P3IDtvtNXgHowtRWYb7kiubt8sQPFvfVIVU/jLw2hzeSlNt0FU+Uw==}
     engines: {node: '>=8'}
     peerDependencies:
       react: '>=16.0.0'
@@ -521,6 +538,12 @@ packages:
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
+
+  '@rc-component/util@1.2.2':
+    resolution: {integrity: sha512-p3zQr9Wu8BKncqmuW23olzBoAFsN8PYMS9FaI4JwJLwknH7DvfHAr1fwbfl9aAWw4Jva64ucpenbgG4fznLUSw==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1200,6 +1223,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-mobile@5.0.0:
+    resolution: {integrity: sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -1919,6 +1945,10 @@ snapshots:
     dependencies:
       '@ant-design/fast-color': 2.0.6
 
+  '@ant-design/colors@8.0.0':
+    dependencies:
+      '@ant-design/fast-color': 3.0.0
+
   '@ant-design/cssinjs-utils@1.1.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@ant-design/cssinjs': 1.24.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1943,6 +1973,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.3
 
+  '@ant-design/fast-color@3.0.0': {}
+
   '@ant-design/icons-svg@4.4.2': {}
 
   '@ant-design/icons@5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
@@ -1952,6 +1984,15 @@ snapshots:
       '@babel/runtime': 7.28.3
       classnames: 2.5.1
       rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@ant-design/icons@6.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@ant-design/colors': 8.0.0
+      '@ant-design/icons-svg': 4.4.2
+      '@rc-component/util': 1.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      classnames: 2.5.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
@@ -2315,6 +2356,13 @@ snapshots:
       rc-util: 5.44.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+
+  '@rc-component/util@1.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      is-mobile: 5.0.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-is: 18.3.1
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -3034,6 +3082,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-mobile@5.0.0: {}
 
   is-number@7.0.0: {}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,29 +1,31 @@
 import { RouterProvider } from 'react-router'
 import { Toaster } from 'sonner'
 import './App.css'
-import { ErrorBoundary } from './components'
+import { ErrorBoundary, ThemeProvider } from './components'
 import { router } from './router'
 
 function App() {
   return (
-    <ErrorBoundary
-      enableErrorReporting={true}
-      onError={(error, errorInfo) => {
-        // 全局错误处理逻辑
-        console.error('[App] Global error caught:', error, errorInfo);
+    <ThemeProvider>
+      <ErrorBoundary
+        enableErrorReporting={true}
+        onError={(error, errorInfo) => {
+          // 全局错误处理逻辑
+          console.error('[App] Global error caught:', error, errorInfo);
 
-        // 这里可以添加错误上报到监控系统的逻辑
-      }}
-    >
-      {/* 页面内容 */}
-      <div className="min-h-screen bg-background">
-        <RouterProvider router={router}>
-        </RouterProvider>
-      </div>
+          // 这里可以添加错误上报到监控系统的逻辑
+        }}
+      >
+        {/* 页面内容 */}
+        <div className="min-h-screen bg-background theme-bg">
+          <RouterProvider router={router}>
+          </RouterProvider>
+        </div>
 
-      {/* Toast 通知组件 */}
-      <Toaster richColors position="top-right" />
-    </ErrorBoundary>
+        {/* Toast 通知组件 */}
+        <Toaster richColors position="top-right" />
+      </ErrorBoundary>
+    </ThemeProvider>
   )
 }
 

--- a/frontend/src/components/common/ThemeProvider.tsx
+++ b/frontend/src/components/common/ThemeProvider.tsx
@@ -1,0 +1,41 @@
+/**
+ * 主题提供者组件
+ * 为整个应用提供主题支持，包括 Ant Design 主题配置
+ */
+
+import { getAntdTheme } from '@/config/theme';
+import { useThemeStore } from '@/stores/themeStore';
+import { ConfigProvider, theme } from 'antd';
+import React, { useEffect, useMemo } from 'react';
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+/**
+ * 主题提供者组件
+ */
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const { mode, applyTheme } = useThemeStore();
+  
+  // 初始化时应用主题
+  useEffect(() => {
+    applyTheme();
+  }, [applyTheme]);
+  
+  // Ant Design 主题配置
+  const antdTheme = useMemo(() => {
+    const themeConfig = getAntdTheme(mode);
+    
+    return {
+      ...themeConfig,
+      algorithm: mode === 'dark' ? theme.darkAlgorithm : theme.defaultAlgorithm,
+    };
+  }, [mode]);
+  
+  return (
+    <ConfigProvider theme={antdTheme}>
+      {children}
+    </ConfigProvider>
+  );
+};

--- a/frontend/src/components/common/ThemeToggle.tsx
+++ b/frontend/src/components/common/ThemeToggle.tsx
@@ -1,0 +1,40 @@
+/**
+ * 主题切换按钮组件
+ * 提供明亮/暗黑主题切换功能
+ */
+
+import { useTheme } from '@/stores/themeStore';
+import { MoonOutlined, SunOutlined } from '@ant-design/icons';
+import { Button } from 'antd';
+import React from 'react';
+
+interface ThemeToggleProps {
+  className?: string;
+  size?: 'small' | 'middle' | 'large';
+  type?: 'default' | 'primary' | 'dashed' | 'link' | 'text';
+  shape?: 'default' | 'circle' | 'round';
+}
+
+/**
+ * 主题切换按钮组件
+ */
+export const ThemeToggle: React.FC<ThemeToggleProps> = ({
+  className,
+  size = 'middle',
+  type = 'text',
+  shape = 'circle',
+}) => {
+  const { mode, toggleTheme } = useTheme();
+  
+  return (
+    <Button
+      className={className}
+      size={size}
+      type={type}
+      shape={shape}
+      icon={mode === 'dark' ? <SunOutlined /> : <MoonOutlined />}
+      onClick={toggleTheme}
+      title={mode === 'dark' ? '切换到明亮主题' : '切换到暗黑主题'}
+    />
+  );
+};

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -1,6 +1,9 @@
+export * from '../../lib/withErrorBoundary';
 export { default as ErrorBoundary } from './ErrorBoundary';
 export type { ErrorBoundaryProps } from './ErrorBoundary';
 export { default as Loading } from './Loading';
 export * from './Pagination';
 export * from './SuspenseWrapper';
-export * from '../../lib/withErrorBoundary';
+export { ThemeProvider } from './ThemeProvider';
+export { ThemeToggle } from './ThemeToggle';
+

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,7 +1,24 @@
-export const Header = () => {
+import { ThemeToggle } from '@/components/common';
+import { Space, Typography } from 'antd';
+import React from 'react';
+import { Link } from 'react-router';
+
+const { Title } = Typography;
+
+export const Header: React.FC = () => {
     return (
-        <header>
-            <h1>Kisesaki Blog</h1>
+        <header className="theme-navbar-bg theme-border border-b px-6 py-4">
+            <div className="max-w-7xl mx-auto flex justify-between items-center">
+                <Link to="/" className="no-underline">
+                    <Title level={2} className="theme-text-primary m-0">
+                        Kisesaki Blog
+                    </Title>
+                </Link>
+                
+                <Space>
+                    <ThemeToggle />
+                </Space>
+            </div>
         </header>
     );
 };

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -2,3 +2,8 @@
  * 全局配置文件
  * 包含应用常量、环境变量、API 端点等配置
  */
+
+export * from './api';
+export * from './constants';
+export * from './theme';
+

--- a/frontend/src/config/theme.ts
+++ b/frontend/src/config/theme.ts
@@ -1,0 +1,165 @@
+/**
+ * 主题配置文件
+ * 定义明亮和暗黑两套主题的颜色系统
+ */
+
+export type ThemeMode = 'light' | 'dark';
+
+/**
+ * 主题颜色配置
+ */
+export interface ThemeColors {
+  // 背景色
+  background: string;
+  cardBackground: string;
+  navbarBackground: string;
+  
+  // 文本色
+  primaryText: string;
+  secondaryText: string;
+  
+  // 主色调
+  primary: string;
+  primaryHover: string;
+  
+  // 边框和分割线
+  border: string;
+  divider: string;
+  
+  // 阴影
+  shadow: string;
+  
+  // 状态色
+  success: string;
+  warning: string;
+  error: string;
+  info: string;
+}
+
+/**
+ * 明亮主题配置
+ */
+export const lightTheme: ThemeColors = {
+  background: '#F8F8F8',
+  cardBackground: '#FFFFFF',
+  navbarBackground: '#FFFFFF',
+  
+  primaryText: '#333333',
+  secondaryText: '#666666',
+  
+  primary: '#28A745',
+  primaryHover: '#218838',
+  
+  border: '#E0E0E0',
+  divider: '#E0E0E0',
+  
+  shadow: 'rgba(0, 0, 0, 0.1)',
+  
+  success: '#28A745',
+  warning: '#FFC107',
+  error: '#DC3545',
+  info: '#17A2B8',
+};
+
+/**
+ * 暗黑主题配置
+ */
+export const darkTheme: ThemeColors = {
+  background: '#2C2C2C',
+  cardBackground: '#3C3C3C',
+  navbarBackground: '#1A1A1A',
+  
+  primaryText: '#E0E0E0',
+  secondaryText: '#A0A0A0',
+  
+  primary: '#64B5F6',
+  primaryHover: '#42A5F5',
+  
+  border: '#555555',
+  divider: '#555555',
+  
+  shadow: 'rgba(0, 0, 0, 0.5)',
+  
+  success: '#8BC34A',
+  warning: '#FFEB3B',
+  error: '#EF5350',
+  info: '#29B6F6',
+};
+
+/**
+ * 主题配置映射
+ */
+export const themes: Record<ThemeMode, ThemeColors> = {
+  light: lightTheme,
+  dark: darkTheme,
+};
+
+/**
+ * Ant Design 主题令牌配置
+ */
+export const getAntdTheme = (mode: ThemeMode) => {
+  const colors = themes[mode];
+  
+  return {
+    token: {
+      // 基础色彩
+      colorPrimary: colors.primary,
+      colorSuccess: colors.success,
+      colorWarning: colors.warning,
+      colorError: colors.error,
+      colorInfo: colors.info,
+      
+      // 背景色
+      colorBgContainer: colors.cardBackground,
+      colorBgElevated: colors.cardBackground,
+      colorBgLayout: colors.background,
+      
+      // 文本色
+      colorText: colors.primaryText,
+      colorTextSecondary: colors.secondaryText,
+      colorTextTertiary: colors.secondaryText,
+      
+      // 边框色
+      colorBorder: colors.border,
+      colorBorderSecondary: colors.divider,
+      
+      // 基础配置
+      borderRadius: 8,
+      fontSize: 14,
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+      
+      // 阴影
+      boxShadow: `0 2px 8px ${colors.shadow}`,
+      boxShadowSecondary: `0 1px 4px ${colors.shadow}`,
+    },
+    components: {
+      Button: {
+        colorPrimary: colors.primary,
+        colorPrimaryHover: colors.primaryHover,
+      },
+      Menu: {
+        itemBg: 'transparent',
+        itemSelectedBg: colors.primary + '15', // 15% 透明度
+        itemHoverBg: colors.primary + '10', // 10% 透明度
+      },
+      Card: {
+        colorBgContainer: colors.cardBackground,
+        colorBorderSecondary: colors.border,
+      },
+      Layout: {
+        colorBgContainer: colors.background,
+        colorBgHeader: colors.navbarBackground,
+        colorBgBody: colors.background,
+      },
+      Input: {
+        colorBorder: colors.border,
+        colorBgContainer: colors.cardBackground,
+      },
+      Table: {
+        colorBgContainer: colors.cardBackground,
+        colorBorderSecondary: colors.border,
+      },
+    },
+    algorithm: mode === 'dark' ? 'darkAlgorithm' : 'defaultAlgorithm',
+  };
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,6 +8,8 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+  
+  /* Shadcn/ui 颜色变量 */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -39,82 +41,197 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  
+  /* 自定义主题颜色变量 */
+  --color-theme-background: var(--theme-background);
+  --color-theme-card-background: var(--theme-card-background);
+  --color-theme-navbar-background: var(--theme-navbar-background);
+  --color-theme-primary-text: var(--theme-primary-text);
+  --color-theme-secondary-text: var(--theme-secondary-text);
+  --color-theme-primary: var(--theme-primary);
+  --color-theme-primary-hover: var(--theme-primary-hover);
+  --color-theme-border: var(--theme-border);
+  --color-theme-divider: var(--theme-divider);
+  --color-theme-shadow: var(--theme-shadow);
+  --color-theme-success: var(--theme-success);
+  --color-theme-warning: var(--theme-warning);
+  --color-theme-error: var(--theme-error);
+  --color-theme-info: var(--theme-info);
 }
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  
+  /* Shadcn/ui 明亮主题 */
+  --background: #F8F8F8;
+  --foreground: #333333;
+  --card: #FFFFFF;
+  --card-foreground: #333333;
+  --popover: #FFFFFF;
+  --popover-foreground: #333333;
+  --primary: #28A745;
+  --primary-foreground: #FFFFFF;
+  --secondary: #F8F8F8;
+  --secondary-foreground: #333333;
+  --muted: #F8F8F8;
+  --muted-foreground: #666666;
+  --accent: #28A745;
+  --accent-foreground: #FFFFFF;
+  --destructive: #DC3545;
+  --border: #E0E0E0;
+  --input: #E0E0E0;
+  --ring: #28A745;
+  --chart-1: #28A745;
+  --chart-2: #17A2B8;
+  --chart-3: #FFC107;
+  --chart-4: #DC3545;
+  --chart-5: #6F42C1;
+  --sidebar: #FFFFFF;
+  --sidebar-foreground: #333333;
+  --sidebar-primary: #28A745;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #F8F8F8;
+  --sidebar-accent-foreground: #333333;
+  --sidebar-border: #E0E0E0;
+  --sidebar-ring: #28A745;
+  
+  /* 自定义主题变量 - 明亮主题 */
+  --theme-background: #F8F8F8;
+  --theme-card-background: #FFFFFF;
+  --theme-navbar-background: #FFFFFF;
+  --theme-primary-text: #333333;
+  --theme-secondary-text: #666666;
+  --theme-primary: #28A745;
+  --theme-primary-hover: #218838;
+  --theme-border: #E0E0E0;
+  --theme-divider: #E0E0E0;
+  --theme-shadow: rgba(0, 0, 0, 0.1);
+  --theme-success: #28A745;
+  --theme-warning: #FFC107;
+  --theme-error: #DC3545;
+  --theme-info: #17A2B8;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  /* Shadcn/ui 暗黑主题 */
+  --background: #2C2C2C;
+  --foreground: #E0E0E0;
+  --card: #3C3C3C;
+  --card-foreground: #E0E0E0;
+  --popover: #3C3C3C;
+  --popover-foreground: #E0E0E0;
+  --primary: #64B5F6;
+  --primary-foreground: #1A1A1A;
+  --secondary: #555555;
+  --secondary-foreground: #E0E0E0;
+  --muted: #555555;
+  --muted-foreground: #A0A0A0;
+  --accent: #64B5F6;
+  --accent-foreground: #1A1A1A;
+  --destructive: #EF5350;
+  --border: #555555;
+  --input: #555555;
+  --ring: #64B5F6;
+  --chart-1: #64B5F6;
+  --chart-2: #29B6F6;
+  --chart-3: #FFEB3B;
+  --chart-4: #EF5350;
+  --chart-5: #AB47BC;
+  --sidebar: #3C3C3C;
+  --sidebar-foreground: #E0E0E0;
+  --sidebar-primary: #64B5F6;
+  --sidebar-primary-foreground: #1A1A1A;
+  --sidebar-accent: #555555;
+  --sidebar-accent-foreground: #E0E0E0;
+  --sidebar-border: #555555;
+  --sidebar-ring: #64B5F6;
+  
+  /* 自定义主题变量 - 暗黑主题 */
+  --theme-background: #2C2C2C;
+  --theme-card-background: #3C3C3C;
+  --theme-navbar-background: #1A1A1A;
+  --theme-primary-text: #E0E0E0;
+  --theme-secondary-text: #A0A0A0;
+  --theme-primary: #64B5F6;
+  --theme-primary-hover: #42A5F5;
+  --theme-border: #555555;
+  --theme-divider: #555555;
+  --theme-shadow: rgba(0, 0, 0, 0.5);
+  --theme-success: #8BC34A;
+  --theme-warning: #FFEB3B;
+  --theme-error: #EF5350;
+  --theme-info: #29B6F6;
 }
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    border-color: var(--border);
+    outline-color: var(--ring);
+    outline-offset: 2px;
   }
+  
   body {
-    @apply bg-background text-foreground;
+    background-color: var(--background);
+    color: var(--foreground);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    line-height: 1.6;
   }
+  
+  /* 自定义主题类 */
+  .theme-bg {
+    background-color: var(--theme-background);
+  }
+  
+  .theme-card-bg {
+    background-color: var(--theme-card-background);
+  }
+  
+  .theme-navbar-bg {
+    background-color: var(--theme-navbar-background);
+  }
+  
+  .theme-text-primary {
+    color: var(--theme-primary-text);
+  }
+  
+  .theme-text-secondary {
+    color: var(--theme-secondary-text);
+  }
+  
+  .theme-primary {
+    color: var(--theme-primary);
+  }
+  
+  .theme-primary-bg {
+    background-color: var(--theme-primary);
+  }
+  
+  .theme-border {
+    border-color: var(--theme-border);
+  }
+  
+  .theme-shadow {
+    box-shadow: 0 2px 8px var(--theme-shadow);
+  }
+  
+  .theme-success {
+    color: var(--theme-success);
+  }
+  
+  .theme-warning {
+    color: var(--theme-warning);
+  }
+  
+  .theme-error {
+    color: var(--theme-error);
+  }
+  
+  .theme-info {
+    color: var(--theme-info);
+  }
+}
+
+/* 平滑过渡动画 */
+* {
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }

--- a/frontend/src/pages/Blog/HomePage.tsx
+++ b/frontend/src/pages/Blog/HomePage.tsx
@@ -2,10 +2,33 @@
  * 博客首页
  * 展示最新文章列表、置顶文章、分页等
  */
-const HomePage = () => {
+import { Typography } from 'antd';
+import React from 'react';
+
+const { Title, Paragraph } = Typography;
+
+const HomePage: React.FC = () => {
     return (
-        <div>HomePage</div>
-    )
-}
+        <div className="theme-bg min-h-screen">
+            <div className="max-w-4xl mx-auto p-6">
+                <div className="text-center mb-8">
+                    <Title level={1} className="theme-text-primary">
+                        Kisesaki Blog
+                    </Title>
+                    <Paragraph className="theme-text-secondary text-lg">
+                        欢迎来到我的个人博客
+                    </Paragraph>
+                </div>
+
+                {/* TODO: 在这里添加文章列表、分页等内容 */}
+                <div className="text-center">
+                    <Paragraph className="theme-text-secondary">
+                        博客内容正在开发中...
+                    </Paragraph>
+                </div>
+            </div>
+        </div>
+    );
+};
 
 export default HomePage;

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -2,3 +2,7 @@
  * Zustand store 导出文件
  * 统一导出所有状态管理 store
  */
+
+export { useAuthStore } from './authStore';
+export { useTheme, useThemeStore } from './themeStore';
+

--- a/frontend/src/stores/themeStore.ts
+++ b/frontend/src/stores/themeStore.ts
@@ -1,0 +1,103 @@
+/**
+ * 主题状态管理 Store
+ * 管理主题切换、持久化存储等功能
+ */
+
+import type { ThemeColors, ThemeMode } from '@/config/theme';
+import { themes } from '@/config/theme';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface ThemeState {
+  /** 当前主题模式 */
+  mode: ThemeMode;
+  /** 当前主题颜色配置 */
+  colors: ThemeColors;
+  /** 切换主题 */
+  toggleTheme: () => void;
+  /** 设置主题 */
+  setTheme: (mode: ThemeMode) => void;
+  /** 应用主题到 DOM */
+  applyTheme: () => void;
+}
+
+/**
+ * 主题 Store
+ */
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set, get) => ({
+      mode: 'light',
+      colors: themes.light,
+      
+      toggleTheme: () => {
+        const currentMode = get().mode;
+        const newMode: ThemeMode = currentMode === 'light' ? 'dark' : 'light';
+        set({
+          mode: newMode,
+          colors: themes[newMode],
+        });
+        get().applyTheme();
+      },
+      
+      setTheme: (mode: ThemeMode) => {
+        set({
+          mode,
+          colors: themes[mode],
+        });
+        get().applyTheme();
+      },
+      
+      applyTheme: () => {
+        const { mode, colors } = get();
+        const root = document.documentElement;
+        
+        // 设置 CSS 自定义属性
+        root.style.setProperty('--theme-background', colors.background);
+        root.style.setProperty('--theme-card-background', colors.cardBackground);
+        root.style.setProperty('--theme-navbar-background', colors.navbarBackground);
+        root.style.setProperty('--theme-primary-text', colors.primaryText);
+        root.style.setProperty('--theme-secondary-text', colors.secondaryText);
+        root.style.setProperty('--theme-primary', colors.primary);
+        root.style.setProperty('--theme-primary-hover', colors.primaryHover);
+        root.style.setProperty('--theme-border', colors.border);
+        root.style.setProperty('--theme-divider', colors.divider);
+        root.style.setProperty('--theme-shadow', colors.shadow);
+        root.style.setProperty('--theme-success', colors.success);
+        root.style.setProperty('--theme-warning', colors.warning);
+        root.style.setProperty('--theme-error', colors.error);
+        root.style.setProperty('--theme-info', colors.info);
+        
+        // 设置 dark class 用于 Tailwind CSS
+        if (mode === 'dark') {
+          root.classList.add('dark');
+        } else {
+          root.classList.remove('dark');
+        }
+        
+        // 设置主题属性用于其他样式
+        root.setAttribute('data-theme', mode);
+      },
+    }),
+    {
+      name: 'theme-storage',
+    }
+  )
+);
+
+/**
+ * 主题 Hook
+ * 提供便捷的主题操作方法
+ */
+export const useTheme = () => {
+  const { mode, colors, toggleTheme, setTheme } = useThemeStore();
+  
+  return {
+    mode,
+    colors,
+    toggleTheme,
+    setTheme,
+    isDark: mode === 'dark',
+    isLight: mode === 'light',
+  };
+};


### PR DESCRIPTION
### **描述 (Description)**

本次 Pull Request 的主要目标：

- 添加主题切换功能，支持用户在不同主题间切换
- 实现主题提供者组件，统一管理主题状态

此改动涉及的模块：

- `frontend/src/components/common/ThemeProvider.tsx`
- `frontend/src/components/common/ThemeToggle.tsx`
- `frontend/src/stores/themeStore.ts`
- `frontend/package.json`

---

### **主要变更 (Changes)**

- **新增**: 主题提供者组件 (ThemeProvider.tsx)，主题切换组件 (ThemeToggle.tsx)，主题状态管理 (themeStore.ts)
- **修改**: 更新 package.json 添加 @ant-design/icons 依赖
- **删除**: 无
- **优化/重构**: 无

---

### **影响范围 (Impact)**

- 前端主题系统，支持动态主题切换
- 涉及前端 UI 组件，可能影响用户界面的显示效果
- 不涉及数据库或接口变更
- 向下兼容性良好，无风险