### PR TITLE
🐞 fix(frontend): 修复 Header 滚动监听在 ScrollArea 下失效的问题

### DIFF
--- a/frontend/src/components/layout/Header/useHeader.ts
+++ b/frontend/src/components/layout/Header/useHeader.ts
@@ -17,14 +17,18 @@ export const useHeader = (opts?: { scrollThreshold?: number }) => {
     // 初始化上一次滚动位置
     lastY.current = window.scrollY || 0;
 
-    const onScroll = () => {
+    const onScroll = (e: Event) => {
       // 如果正在滚动，则返回
       if (ticking.current) return;
       ticking.current = true;
 
       // 请求动画帧
       requestAnimationFrame(() => {
-        const y = window.scrollY || 0; // 当前滚动位置
+        const target = e.target as HTMLElement | Window;
+        const y =
+          target === window
+            ? window.pageYOffset
+            : (target as HTMLElement).scrollTop || 0;
         // 页面已滚动超过阈值时显示磨砂效果
         const shouldFrost = y > threshold;
         setFrosted(shouldFrost);
@@ -36,10 +40,13 @@ export const useHeader = (opts?: { scrollThreshold?: number }) => {
     };
 
     // 监听滚动事件
-    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("scroll", onScroll, {
+      passive: true,
+      capture: true,
+    });
 
     // 清理函数，useEffect 要求通过返回一个“清理函数”来处理副作用的收尾工作
-    return () => window.removeEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll, true);
   }, [threshold]);
 
   const handleHeaderMouseEnter = () => {


### PR DESCRIPTION
- 修改 useHeader Hook 以支持内部滚动容器监听
- 使用 capture: true 捕获所有滚动事件
- 区分 window 和内部元素的滚动位置获取，确保 frosted 状态正确更新