### PR TITLE
✨feat(mapper/entity/database): 添加博客内容数据实体、映射器与建表迁移

### DIFF
--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/category/entity/Categories.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/category/entity/Categories.java
@@ -1,0 +1,45 @@
+package com.kisesaki.blog.content.category.entity;
+
+import java.time.OffsetDateTime;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@TableName("categories")
+public class Categories {
+
+    /* 分类唯一ID（自增） */
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /* 分类名称 */
+    private String name;
+
+    /* 分类别名（URL 友好） */
+    private String slug;
+
+    /* 分类描述 */
+    private String description;
+
+    /* 父分类ID（自关联） */
+    private Long parentId;
+
+    /* 排序顺序 */
+    private Integer sortOrder;
+
+    /* 文章数量 */
+    private Integer postCount;
+
+    /* 创建时间 */
+    private OffsetDateTime createdAt;
+
+    /* 更新时间 */
+    private OffsetDateTime updatedAt;
+
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/category/mapper/CategoriesMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/category/mapper/CategoriesMapper.java
@@ -1,0 +1,9 @@
+package com.kisesaki.blog.content.category.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.kisesaki.blog.content.category.entity.Categories;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface CategoriesMapper extends BaseMapper<Categories> {
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/PostMeta.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/PostMeta.java
@@ -1,0 +1,36 @@
+package com.kisesaki.blog.content.post.entity;
+
+import java.time.OffsetDateTime;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@TableName("post_meta")
+public class PostMeta {
+
+    /* 元数据唯一ID（自增） */
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /* 文章ID，外键 references posts.id */
+    private Long postId;
+
+    /* 元数据键名 */
+    private String metaKey;
+
+    /* 元数据值 */
+    private String metaValue;
+
+    /* 创建时间 */
+    private OffsetDateTime createdAt;
+
+    /* 更新时间 */
+    private OffsetDateTime updatedAt;
+
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/PostRevisions.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/PostRevisions.java
@@ -1,0 +1,45 @@
+package com.kisesaki.blog.content.post.entity;
+
+import java.time.OffsetDateTime;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * post_revisions 表实体
+ */
+@Data
+@NoArgsConstructor
+@TableName("post_revisions")
+public class PostRevisions {
+
+    /* 版本唯一ID（自增） */
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /* 文章ID，外键 references posts.id */
+    private Long postId;
+
+    /* 版本号 */
+    private Integer version;
+
+    /* 标题 */
+    private String title;
+
+    /* 内容 */
+    private String content;
+
+    /* 摘要 */
+    private String summary;
+
+    /* 创建者ID，外键 references users.id */
+    private Long createdBy;
+
+    /* 创建时间 */
+    private OffsetDateTime createdAt;
+
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/PostTags.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/PostTags.java
@@ -1,0 +1,24 @@
+package com.kisesaki.blog.content.post.entity;
+
+import java.time.OffsetDateTime;
+
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@TableName("post_tags")
+public class PostTags {
+
+    /* 文章ID，外键 references posts.id */
+    private Long postId;
+
+    /* 标签ID，外键 references tags.id */
+    private Long tagId;
+
+    /* 创建时间 */
+    private OffsetDateTime createdAt;
+
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/Posts.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/Posts.java
@@ -1,0 +1,111 @@
+package com.kisesaki.blog.content.post.entity;
+
+import java.time.OffsetDateTime;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * posts 表实体
+ */
+@Data
+@NoArgsConstructor
+@TableName("posts")
+public class Posts {
+
+    /* 文章唯一ID（自增） */
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /* 作者ID，外键 references user.id， NOT NULL */
+    private Long authorId;
+
+    /* 分类ID，外键 references categories.id */
+    private Long categoryId;
+
+    /* 标题 */
+    private String title;
+
+    /* URL 友好别名（唯一） */
+    private String slug;
+
+    /* 摘要/简介 */
+    private String excerpt;
+
+    /* Markdown 原始内容，NOT NULL */
+    private String content;
+
+    /* 渲染后的 HTML 缓存 */
+    private String htmlContent;
+
+    /* 封面图片 URL */
+    private String coverImageUrl;
+
+    /* 特色图片 URL */
+    private String featuredImageUrl;
+
+    /* 状态：draft, published, archived, deleted；默认 draft */
+    private String status;
+
+    /* 可见性：public, private, password_protected；默认 public */
+    private String visibility;
+
+    /* 访问密码（仅当 visibility 为 password_protected 时有效） */
+    private String password;
+
+    /* 浏览次数，默认 0 */
+    private Integer viewCount;
+
+    /* 点赞数量，默认 0 */
+    private Integer likeCount;
+
+    /* 评论数量，默认 0 */
+    private Integer commentCount;
+
+    /* 分享数量，默认 0 */
+    private Integer shareCount;
+
+    /* 预估阅读时间（分钟） */
+    private Integer readingTime;
+
+    /* 字数统计 */
+    private Integer wordCount;
+
+    /* 是否为精选文章 */
+    private Boolean isFeatured;
+
+    /* 是否置顶 */
+    private Boolean isTop;
+
+    /* 是否允许评论，默认 true */
+    private Boolean allowComments;
+
+    /* SEO 标题 */
+    private String seoTitle;
+
+    /* SEO 描述 */
+    private String seoDescription;
+
+    /* SEO 关键词，逗号分隔 */
+    private String seoKeywords;
+
+    /* 发布时间（带时区） */
+    private OffsetDateTime publishedAt;
+
+    /* 计划发布时间（用于定时发布） */
+    private OffsetDateTime scheduledAt;
+
+    /* 最后修改时间 */
+    private OffsetDateTime lastModifiedAt;
+
+    /* 创建时间，默认 NOW() */
+    private OffsetDateTime createdAt;
+
+    /* 更新时间，默认 NOW() */
+    private OffsetDateTime updatedAt;
+
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostMetaMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostMetaMapper.java
@@ -1,0 +1,9 @@
+package com.kisesaki.blog.content.post.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.kisesaki.blog.content.post.entity.PostMeta;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PostMetaMapper extends BaseMapper<PostMeta> {
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostRevisionsMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostRevisionsMapper.java
@@ -1,0 +1,9 @@
+package com.kisesaki.blog.content.post.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.kisesaki.blog.content.post.entity.PostRevisions;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PostRevisionsMapper extends BaseMapper<PostRevisions> {
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostTagsMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostTagsMapper.java
@@ -1,0 +1,9 @@
+package com.kisesaki.blog.content.post.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.kisesaki.blog.content.post.entity.PostTags;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PostTagsMapper extends BaseMapper<PostTags> {
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostsMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostsMapper.java
@@ -1,0 +1,9 @@
+package com.kisesaki.blog.content.post.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.kisesaki.blog.content.post.entity.Posts;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PostsMapper extends BaseMapper<Posts> {
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/entity/Tags.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/entity/Tags.java
@@ -1,0 +1,39 @@
+package com.kisesaki.blog.content.tag.entity;
+
+import java.time.OffsetDateTime;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@TableName("tags")
+public class Tags {
+
+    /* 标签唯一ID（自增） */
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /* 标签名称 */
+    private String name;
+
+    /* 标签别名（URL 友好） */
+    private String slug;
+
+    /* 标签描述 */
+    private String description;
+
+    /* 颜色（HEX） */
+    private String color;
+
+    /* 使用该标签的文章数量 */
+    private Integer postCount;
+
+    /* 创建时间 */
+    private OffsetDateTime createdAt;
+
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
@@ -1,0 +1,9 @@
+package com.kisesaki.blog.content.tag.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.kisesaki.blog.content.tag.entity.Tags;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface TagsMapper extends BaseMapper<Tags> {
+}

--- a/backend/blog-backend/src/main/resources/db/migration/V5__create_blog_post_tables.sql
+++ b/backend/blog-backend/src/main/resources/db/migration/V5__create_blog_post_tables.sql
@@ -1,0 +1,145 @@
+-- V5__create_blog_post_tables.sql
+-- Flyway migration: create blog-related tables (posts, categories, tags, post_tags, post_meta, post_revisions)
+-- Generated based on Java entity classes under com.kisesaki.blog.content.*
+
+-- 1) posts 表
+CREATE TABLE IF NOT EXISTS posts (
+    id BIGSERIAL PRIMARY KEY,
+    author_id BIGINT NOT NULL,
+    category_id BIGINT,
+    title VARCHAR(255) NOT NULL,
+    slug VARCHAR(255),
+    excerpt TEXT,
+    content TEXT NOT NULL,
+    html_content TEXT,
+    cover_image_url VARCHAR(1024),
+    featured_image_url VARCHAR(1024),
+    status VARCHAR(32) NOT NULL DEFAULT 'draft',
+    visibility VARCHAR(32) NOT NULL DEFAULT 'public',
+    password VARCHAR(255),
+    view_count INTEGER NOT NULL DEFAULT 0,
+    like_count INTEGER NOT NULL DEFAULT 0,
+    comment_count INTEGER NOT NULL DEFAULT 0,
+    share_count INTEGER NOT NULL DEFAULT 0,
+    reading_time INTEGER,
+    word_count INTEGER,
+    is_featured BOOLEAN NOT NULL DEFAULT FALSE,
+    is_top BOOLEAN NOT NULL DEFAULT FALSE,
+    allow_comments BOOLEAN NOT NULL DEFAULT TRUE,
+    seo_title VARCHAR(255),
+    seo_description VARCHAR(512),
+    seo_keywords VARCHAR(512),
+    published_at TIMESTAMPTZ,
+    scheduled_at TIMESTAMPTZ,
+    last_modified_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 唯一索引：slug
+CREATE UNIQUE INDEX IF NOT EXISTS ux_posts_slug ON posts (slug);
+
+-- 索引：author, category, status, visibility
+CREATE INDEX IF NOT EXISTS ix_posts_author_id ON posts (author_id);
+
+CREATE INDEX IF NOT EXISTS ix_posts_category_id ON posts (category_id);
+
+CREATE INDEX IF NOT EXISTS ix_posts_status ON posts (status);
+
+CREATE INDEX IF NOT EXISTS ix_posts_visibility ON posts (visibility);
+
+-- 外键：引用 "user" 表（注意 user 在项目中用双引号）
+ALTER TABLE posts
+ADD CONSTRAINT fk_posts_author_user FOREIGN KEY (author_id) REFERENCES "user" (id) ON DELETE SET NULL;
+
+-- 如果存在 categories 表，再添加外键约束（安全起见用 ALTER TABLE 添加）
+ALTER TABLE posts
+ADD CONSTRAINT fk_posts_category FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE SET NULL;
+
+-- 2) categories 表
+CREATE TABLE IF NOT EXISTS categories (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(128) NOT NULL,
+    slug VARCHAR(128),
+    description TEXT,
+    parent_id BIGINT,
+    sort_order INTEGER DEFAULT 0,
+    post_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_categories_slug ON categories (slug);
+
+CREATE INDEX IF NOT EXISTS ix_categories_parent_id ON categories (parent_id);
+
+ALTER TABLE categories
+ADD CONSTRAINT fk_categories_parent FOREIGN KEY (parent_id) REFERENCES categories (id) ON DELETE SET NULL;
+
+-- 3) tags 表
+CREATE TABLE IF NOT EXISTS tags (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(128) NOT NULL,
+    slug VARCHAR(128),
+    description TEXT,
+    color VARCHAR(32),
+    post_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_tags_slug ON tags (slug);
+
+-- 4) post_tags 关联表
+CREATE TABLE IF NOT EXISTS post_tags (
+    post_id BIGINT NOT NULL,
+    tag_id BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (post_id, tag_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_post_tags_post_id ON post_tags (post_id);
+
+CREATE INDEX IF NOT EXISTS ix_post_tags_tag_id ON post_tags (tag_id);
+
+ALTER TABLE post_tags
+ADD CONSTRAINT fk_post_tags_post FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE CASCADE,
+ADD CONSTRAINT fk_post_tags_tag FOREIGN KEY (tag_id) REFERENCES tags (id) ON DELETE CASCADE;
+
+-- 5) post_meta 表
+CREATE TABLE IF NOT EXISTS post_meta (
+    id BIGSERIAL PRIMARY KEY,
+    post_id BIGINT NOT NULL,
+    meta_key VARCHAR(191) NOT NULL,
+    meta_value TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_post_meta_post_key ON post_meta (post_id, meta_key);
+
+CREATE INDEX IF NOT EXISTS ix_post_meta_post_id ON post_meta (post_id);
+
+ALTER TABLE post_meta
+ADD CONSTRAINT fk_post_meta_post FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE CASCADE;
+
+-- 6) post_revisions 表
+CREATE TABLE IF NOT EXISTS post_revisions (
+    id BIGSERIAL PRIMARY KEY,
+    post_id BIGINT NOT NULL,
+    version INTEGER NOT NULL,
+    title VARCHAR(255),
+    content TEXT,
+    summary TEXT,
+    created_by BIGINT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_post_revisions_post_version ON post_revisions (post_id, version);
+
+CREATE INDEX IF NOT EXISTS ix_post_revisions_post_id ON post_revisions (post_id);
+
+ALTER TABLE post_revisions
+ADD CONSTRAINT fk_post_revisions_post FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE CASCADE,
+ADD CONSTRAINT fk_post_revisions_created_by_user FOREIGN KEY (created_by) REFERENCES "user" (id) ON DELETE SET NULL;
+
+-- End of migration


### PR DESCRIPTION
### **描述 (Description)**

本次 Pull Request 的主要目标：

- 添加博客相关的数据库表迁移脚本，用于存储文章、分类、标签及其关联数据。
- 新增实体类和 MyBatis 映射器接口，为博客内容的持久化层提供基础结构。

此改动涉及的模块：

- `backend/blog-backend/src/main/resources/db/migration`
- `backend/blog-backend/src/main/java/com/kisesaki/blog/content`（entity/mapper 子包）

---

### **主要变更 (Changes)**

- **新增**: 
  - `backend/blog-backend/src/main/resources/db/migration/V5__create_blog_post_tables.sql`（Flyway 迁移脚本）
  - 实体类：
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/category/entity/Categories.java`
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/PostMeta.java`
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/PostRevisions.java`
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/PostTags.java`
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/entity/Posts.java`
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/entity/Tags.java`
  - 映射器接口（Mapper）：
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/category/mapper/CategoriesMapper.java`
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostMetaMapper.java`
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostRevisionsMapper.java`
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostTagsMapper.java`
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostsMapper.java`
    - `backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java`
- **修改**: 无
- **删除**: 无
- **优化/重构**: 无（本次为新增数据层基础结构）

---

### **影响范围 (Impact)**

- 为博客内容模块提供数据库与持久层基础，后续服务层和 API 层可直接依赖这些实体与映射器进行 CRUD 操作。
- 涉及数据库变更：新增 Flyway 迁移脚本，会在下次应用迁移时创建新表，请在部署前确认数据库备份和迁移计划。
- 向下兼容性风险：低。新增表与实体不会影响现有表结构；但需注意若后续代码对已有业务查询做联合查询，可能需同步更新查询逻辑。
