### PR TITLE
🐞 fix(post): 修复管理员文章模块 XML DTO 路径导致无法启动

### DIFF
--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/AdminPostController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/AdminPostController.java
@@ -19,7 +19,7 @@ import com.kisesaki.blog.content.post.dto.AdminCommand.AdminPostQueryDto;
 import com.kisesaki.blog.content.post.dto.AdminCommand.AdminPostStatsDto;
 import com.kisesaki.blog.content.post.dto.AdminCommand.AdminPostStatusDto;
 import com.kisesaki.blog.content.post.dto.AdminCommand.AdminUpdatePostRequest;
-import com.kisesaki.blog.content.post.service.PostAdminService;
+import com.kisesaki.blog.content.post.service.AdminPostService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 @PreAuthorize("hasRole('ADMIN')")
 public class AdminPostController {
 
-    private final PostAdminService postAdminService;
+    private final AdminPostService postAdminService;
 
     /**
      * 获取所有文章列表（包含草稿、已删除等）

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/dto/AdminCommand/AdminPostQueryDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/dto/AdminCommand/AdminPostQueryDto.java
@@ -103,6 +103,15 @@ public class AdminPostQueryDto {
         @Schema(description = "评论数量", example = "3")
         private Integer commentCount;
 
+        @Schema(description = "分享数量", example = "2")
+        private Integer shareCount;
+
+        @Schema(description = "阅读时长（分钟）", example = "5")
+        private Integer readingTime;
+
+        @Schema(description = "字数统计", example = "1200")
+        private Integer wordCount;
+
         @Schema(description = "是否为精选文章", example = "false")
         private Boolean isFeatured;
 
@@ -124,10 +133,16 @@ public class AdminPostQueryDto {
         @Schema(description = "发布时间")
         private OffsetDateTime publishedAt;
 
+        @Schema(description = "定时发布时间")
+        private OffsetDateTime scheduledAt;
+
         @Schema(description = "创建时间")
         private OffsetDateTime createdAt;
 
         @Schema(description = "更新时间")
         private OffsetDateTime updatedAt;
+
+        @Schema(description = "最后修改时间")
+        private OffsetDateTime lastModifiedAt;
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/service/AdminPostService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/service/AdminPostService.java
@@ -9,6 +9,7 @@ import org.springframework.util.StringUtils;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.common.exception.BusinessException;
 import com.kisesaki.blog.common.markdown.MarkdownService;
@@ -40,7 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class PostAdminService {
+public class AdminPostService {
 
     private final PostsMapper postsMapper;
     private final PostTagsMapper postTagsMapper;
@@ -66,7 +67,7 @@ public class PostAdminService {
         }
 
         // 创建分页对象
-        com.baomidou.mybatisplus.extension.plugins.pagination.Page<AdminPostQueryDto.AdminPostListResponse> page = new com.baomidou.mybatisplus.extension.plugins.pagination.Page<>(
+        Page<AdminPostQueryDto.AdminPostListResponse> page = new Page<>(
                 params.getPageable().getCurrentPage(),
                 params.getPageable().getPageSize());
 

--- a/backend/blog-backend/src/main/resources/mapper/content/post/PostsMapper.xml
+++ b/backend/blog-backend/src/main/resources/mapper/content/post/PostsMapper.xml
@@ -827,7 +827,7 @@
     <!-- ========== 管理员专用查询 ========== -->
 
     <!-- 管理员文章列表响应结果映射 -->
-    <resultMap id="AdminPostListMap" type="com.kisesaki.blog.admin.dto.AdminCommand.AdminPostQueryDto$AdminPostListResponse">
+    <resultMap id="AdminPostListMap" type="com.kisesaki.blog.content.post.dto.AdminCommand.AdminPostQueryDto$AdminPostListResponse">
         <!-- 文章基本信息 -->
         <id property="id" column="post_id"/>
         <result property="title" column="post_title"/>
@@ -1164,7 +1164,7 @@
     </select>
 
     <!-- 获取文章统计数据 -->
-    <select id="getPostStats" resultType="com.kisesaki.blog.admin.dto.AdminCommand.AdminPostStatsDto$PostStatsResponse">
+    <select id="getPostStats" resultType="com.kisesaki.blog.content.post.dto.AdminCommand.AdminPostStatsDto$PostStatsResponse">
         SELECT 
             -- 基础统计
             COUNT(*) AS totalPosts,


### PR DESCRIPTION
### **描述 (Description)**

本次 Pull Request 的主要目标：

- 修复 MyBatis XML 映射中引用的 DTO 路径错误，导致应用启动失败的 BUG。
- 统一 Service 命名风格：将 `PostAdminService` 重命名为 `AdminPostService` 并更新所有引用。
- 为管理员文章查询 DTO 增加统计字段（便于列表页显示/统计）。

此改动涉及的模块：

- backend/blog-backend/src/main/resources/mapper/content/post/PostsMapper.xml
- backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/dto/AdminCommand/AdminPostQueryDto.java
- backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/service/
- backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostsMapper.java
- backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/AdminPostController.java

---

### **主要变更 (Changes)**

- **新增**: 为管理员文章查询 DTO 新增统计字段（AdminPostQueryDto 中的统计响应字段）。
- **修改**: 
  - 修正 `PostsMapper.xml` 中 `resultMap` 的 `type` 为正确的 DTO 路径，解决启动时的类型映射错误。
  - 更新 `PostsMapper.java` 中与管理员分页查询相关的方法签名/引用（确保与 DTO 一致）。
  - 重命名并替换 `PostAdminService` 为 `AdminPostService`，并更新所有引用处（包括 Controller 注入点）。
- **删除**: 无文件删除。
- **优化/重构**: 统一 Service 命名风格（提高代码可读性与一致性），并扩展管理员查询 DTO 的字段以支持统计展示。

---

### **影响范围 (Impact)**

- 影响的功能/模块：管理员端文章管理（文章列表、统计、批量操作等相关接口）。
- 是否涉及数据库/接口/配置变更：不涉及数据库 schema 变更；涉及 MyBatis 映射文件（XML）和代码引用的变更，属于配置/代码修复。
- 是否存在向下兼容性风险：低风险。外部 REST API（URL、请求/响应协议）未改动；新增 DTO 字段为向后兼容的扩展，服务重命名为内部实现细节，不影响对外接口。但请注意：MyBatis 映射类型修正会改变 ORM 映射到对象的行为，已部署的客户端若依赖精确的字段返回结构（非常罕见）需验证。

---

备注：本分支基于 `dev` 分支创建，包含用于修复 XML 中 DTO 路径错误导致无法启动的 BUG 修复、管理员查询 DTO 的小功能扩展（统计字段），以及一次低风险的命名重构。请在合并前运行一次后端启动/集成测试以确认映射与服务引用均正常。
