### PR TITLE
✨feat(permission): 后端权限管理 API 与初始权限数据迁移

### DIFF
--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/AuthController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/AuthController.java
@@ -2,7 +2,6 @@ package com.kisesaki.blog.auth.controller;
 
 import java.util.Set;
 
-import com.kisesaki.blog.auth.dto.request.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,7 +12,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kisesaki.blog.auth.dto.response.LoginResponseDto;
+import com.kisesaki.blog.auth.dto.auth.request.*;
+import com.kisesaki.blog.auth.dto.auth.response.LoginResponseDto;
 import com.kisesaki.blog.auth.service.AuthService;
 import com.kisesaki.blog.common.dto.ApiResponse;
 

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/AuthController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/AuthController.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.auth;
+package com.kisesaki.blog.auth.controller;
 
 import java.util.Set;
 
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kisesaki.blog.auth.dto.response.LoginResponseDto;
+import com.kisesaki.blog.auth.service.AuthService;
 import com.kisesaki.blog.common.dto.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
@@ -1,8 +1,12 @@
 package com.kisesaki.blog.auth.controller;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -12,6 +16,8 @@ import com.kisesaki.blog.auth.dto.permission.PermissionCreateRequest;
 import com.kisesaki.blog.auth.dto.permission.PermissionDetailResponse;
 import com.kisesaki.blog.auth.dto.permission.PermissionListParams;
 import com.kisesaki.blog.auth.dto.permission.PermissionListResponse;
+import com.kisesaki.blog.auth.dto.permission.PermissionOptionResponse;
+import com.kisesaki.blog.auth.dto.permission.PermissionUpdateRequest;
 import com.kisesaki.blog.auth.service.PermissionService;
 import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
@@ -57,6 +63,43 @@ public class PermissionController {
     public ApiResponse<Void> createPermission(@Valid @RequestBody PermissionCreateRequest request) {
         permissionService.createPermission(request);
         return ApiResponse.success("权限创建成功");
+    }
+
+    /**
+     * 更新权限
+     */
+    @PutMapping("/{id}")
+    public ApiResponse<Void> updatePermission(@PathVariable Long id,
+            @Valid @RequestBody PermissionUpdateRequest request) {
+        permissionService.updatePermission(id, request);
+        return ApiResponse.success("权限更新成功");
+    }
+
+    /**
+     * 删除权限
+     */
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deletePermission(@PathVariable Long id) {
+        permissionService.deletePermission(id);
+        return ApiResponse.success("权限删除成功");
+    }
+
+    /**
+     * 获取权限资源类型列表
+     */
+    @GetMapping("/resources")
+    public ApiResponse<List<PermissionOptionResponse>> getPermissionResources() {
+        List<PermissionOptionResponse> resources = permissionService.getPermissionResources();
+        return ApiResponse.success(resources);
+    }
+
+    /**
+     * 获取权限操作类型列表
+     */
+    @GetMapping("/actions")
+    public ApiResponse<List<PermissionOptionResponse>> getPermissionActions() {
+        List<PermissionOptionResponse> actions = permissionService.getPermissionActions();
+        return ApiResponse.success(actions);
     }
 
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
@@ -1,0 +1,21 @@
+package com.kisesaki.blog.auth.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kisesaki.blog.auth.service.PermissionService;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/permissions")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "权限", description = "权限相关接口")
+public class PermissionController {
+
+    private final PermissionService permissionService;
+
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
@@ -1,21 +1,35 @@
 package com.kisesaki.blog.auth.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kisesaki.blog.auth.dto.permission.PermissionListParams;
+import com.kisesaki.blog.auth.dto.permission.PermissionListResponse;
 import com.kisesaki.blog.auth.service.PermissionService;
+import com.kisesaki.blog.common.dto.ApiResponse;
+import com.kisesaki.blog.common.dto.PageResponse;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@RequestMapping("/permissions")
+@RequestMapping("/admin/permissions")
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "权限", description = "权限相关接口")
 public class PermissionController {
 
     private final PermissionService permissionService;
+
+    /**
+     * 获取权限列表
+     */
+    @GetMapping("")
+    public ApiResponse<PageResponse<PermissionListResponse>> getPermissionsList(PermissionListParams params) {
+        PageResponse<PermissionListResponse> pageResponse = permissionService.getPermissionsList(params);
+        return ApiResponse.success(pageResponse);
+    }
 
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
@@ -1,9 +1,8 @@
 package com.kisesaki.blog.auth.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import com.kisesaki.blog.auth.dto.permission.PermissionDetailResponse;
 import com.kisesaki.blog.auth.dto.permission.PermissionListParams;
 import com.kisesaki.blog.auth.dto.permission.PermissionListResponse;
 import com.kisesaki.blog.auth.service.PermissionService;
@@ -30,6 +29,16 @@ public class PermissionController {
     public ApiResponse<PageResponse<PermissionListResponse>> getPermissionsList(PermissionListParams params) {
         PageResponse<PermissionListResponse> pageResponse = permissionService.getPermissionsList(params);
         return ApiResponse.success(pageResponse);
+    }
+
+    /**
+     * 根据ID获取权限详情
+     */
+    @GetMapping("/{id}")
+    public ApiResponse<PermissionDetailResponse> getPermissionById(@PathVariable Long id) {
+        // 这里调用service层的方法获取权限详情
+        PermissionDetailResponse detailResponse = permissionService.getPermissionById(id);
+        return ApiResponse.success(detailResponse);
     }
 
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
@@ -2,10 +2,13 @@ package com.kisesaki.blog.auth.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kisesaki.blog.auth.dto.permission.PermissionCreateRequest;
 import com.kisesaki.blog.auth.dto.permission.PermissionDetailResponse;
 import com.kisesaki.blog.auth.dto.permission.PermissionListParams;
 import com.kisesaki.blog.auth.dto.permission.PermissionListResponse;
@@ -45,6 +48,15 @@ public class PermissionController {
         // 这里调用service层的方法获取权限详情
         PermissionDetailResponse detailResponse = permissionService.getPermissionById(id);
         return ApiResponse.success(detailResponse);
+    }
+
+    /**
+     * 创建权限
+     */
+    @PostMapping("")
+    public ApiResponse<Void> createPermission(@Valid @RequestBody PermissionCreateRequest request) {
+        permissionService.createPermission(request);
+        return ApiResponse.success("权限创建成功");
     }
 
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
@@ -1,6 +1,10 @@
 package com.kisesaki.blog.auth.controller;
 
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.kisesaki.blog.auth.dto.permission.PermissionDetailResponse;
 import com.kisesaki.blog.auth.dto.permission.PermissionListParams;
@@ -10,6 +14,7 @@ import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,7 +31,8 @@ public class PermissionController {
      * 获取权限列表
      */
     @GetMapping("")
-    public ApiResponse<PageResponse<PermissionListResponse>> getPermissionsList(PermissionListParams params) {
+    public ApiResponse<PageResponse<PermissionListResponse>> getPermissionsList(
+            @Valid @RequestParam PermissionListParams params) {
         PageResponse<PermissionListResponse> pageResponse = permissionService.getPermissionsList(params);
         return ApiResponse.success(pageResponse);
     }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/ChangePasswordRequestDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/ChangePasswordRequestDto.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.auth.dto.request;
+package com.kisesaki.blog.auth.dto.auth.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -7,9 +7,9 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class ResetPasswordRequestDto {
-    @NotBlank(message = "邮箱验证令牌不能为空")
-    private String resetToken;
+public class ChangePasswordRequestDto {
+    @NotBlank(message = "旧密码不能为空")
+    private String oldPassword;
 
     @NotBlank(message = "新密码不能为空")
     @Size(min = 6, max = 100, message = "密码长度必须在6-100字符之间")

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/ForgotPasswordRequestDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/ForgotPasswordRequestDto.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.auth.dto.request;
+package com.kisesaki.blog.auth.dto.auth.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/LoginRequestDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/LoginRequestDto.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.auth.dto.request;
+package com.kisesaki.blog.auth.dto.auth.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/LogoutRequestDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/LogoutRequestDto.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.auth.dto.request;
+package com.kisesaki.blog.auth.dto.auth.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/RefreshTokenRequestDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/RefreshTokenRequestDto.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.auth.dto.request;
+package com.kisesaki.blog.auth.dto.auth.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/RegisterRequestDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/RegisterRequestDto.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.auth.dto.request;
+package com.kisesaki.blog.auth.dto.auth.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/ResetPasswordRequestDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/ResetPasswordRequestDto.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.auth.dto.request;
+package com.kisesaki.blog.auth.dto.auth.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -7,9 +7,9 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class ChangePasswordRequestDto {
-    @NotBlank(message = "旧密码不能为空")
-    private String oldPassword;
+public class ResetPasswordRequestDto {
+    @NotBlank(message = "邮箱验证令牌不能为空")
+    private String resetToken;
 
     @NotBlank(message = "新密码不能为空")
     @Size(min = 6, max = 100, message = "密码长度必须在6-100字符之间")

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/VerifyEmailRequestDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/request/VerifyEmailRequestDto.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.auth.dto.request;
+package com.kisesaki.blog.auth.dto.auth.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/response/LoginResponseDto.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/auth/response/LoginResponseDto.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.auth.dto.response;
+package com.kisesaki.blog.auth.dto.auth.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionCreateRequest.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionCreateRequest.java
@@ -1,0 +1,33 @@
+package com.kisesaki.blog.auth.dto.permission;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "权限创建请求参数")
+public class PermissionCreateRequest {
+    @NotBlank(message = "权限名称不能为空")
+    @Size(max = 50, message = "权限名称长度不能超过50个字符")
+    @Schema(description = "权限名称", example = "read_articles", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String name;
+
+    @Size(max = 200, message = "权限描述长度不能超过200个字符")
+    @Schema(description = "权限描述", example = "允许读取文章")
+    private String description;
+
+    @NotBlank(message = "资源类型不能为空")
+    @Size(max = 50, message = "资源类型长度不能超过50个字符")
+    @Schema(description = "资源类型", example = "article", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String resource;
+
+    @NotBlank(message = "操作类型不能为空")
+    @Size(max = 50, message = "操作类型长度不能超过50个字符")
+    @Schema(description = "操作类型", example = "view", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String action;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionDetailResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionDetailResponse.java
@@ -1,0 +1,32 @@
+package com.kisesaki.blog.auth.dto.permission;
+
+import java.time.OffsetDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "权限详情响应数据")
+public class PermissionDetailResponse {
+    @Schema(description = "权限ID", example = "1")
+    private Long id;
+
+    @Schema(description = "权限名称", example = "read_articles")
+    private String name;
+
+    @Schema(description = "权限描述", example = "允许读取文章")
+    private String description;
+
+    @Schema(description = "资源类型", example = "article")
+    private String resource;
+
+    @Schema(description = "操作类型", example = "view")
+    private String action;
+
+    @Schema(description = "创建时间", example = "2023-10-01T12:34:56Z")
+    private OffsetDateTime createdAt;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionListParams.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionListParams.java
@@ -1,0 +1,28 @@
+package com.kisesaki.blog.auth.dto.permission;
+
+import com.kisesaki.blog.common.dto.PageableParams;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "权限列表查询参数")
+public class PermissionListParams {
+    @Valid
+    @Schema(description = "分页参数")
+    private PageableParams pageable = new PageableParams();
+
+    @Schema(description = "权限名称，支持模糊搜索", example = "read")
+    private String name;
+
+    @Schema(description = "资源类型", example = "article")
+    private String resource;
+
+    @Schema(description = "操作类型", example = "view")
+    private String action;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionListResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionListResponse.java
@@ -1,0 +1,32 @@
+package com.kisesaki.blog.auth.dto.permission;
+
+import java.time.OffsetDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "权限列表响应数据")
+public class PermissionListResponse {
+    @Schema(description = "权限ID", example = "1")
+    private Long id;
+
+    @Schema(description = "权限名称", example = "read_articles")
+    private String name;
+
+    @Schema(description = "权限描述", example = "允许读取文章")
+    private String description;
+
+    @Schema(description = "资源类型", example = "article")
+    private String resource;
+
+    @Schema(description = "操作类型", example = "view")
+    private String action;
+
+    @Schema(description = "创建时间", example = "2023-10-01T12:34:56Z")
+    private OffsetDateTime createdAt;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionOptionResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionOptionResponse.java
@@ -1,0 +1,18 @@
+package com.kisesaki.blog.auth.dto.permission;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "权限选项响应数据")
+public class PermissionOptionResponse {
+    @Schema(description = "代码", example = "post")
+    private String code;
+
+    @Schema(description = "描述", example = "文章")
+    private String description;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionUpdateRequest.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/dto/permission/PermissionUpdateRequest.java
@@ -1,0 +1,33 @@
+package com.kisesaki.blog.auth.dto.permission;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "权限更新请求参数")
+public class PermissionUpdateRequest {
+    @NotBlank(message = "权限名称不能为空")
+    @Size(max = 50, message = "权限名称长度不能超过50个字符")
+    @Schema(description = "权限名称", example = "read_articles", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String name;
+
+    @Size(max = 200, message = "权限描述长度不能超过200个字符")
+    @Schema(description = "权限描述", example = "允许读取文章")
+    private String description;
+
+    @NotBlank(message = "资源类型不能为空")
+    @Size(max = 50, message = "资源类型长度不能超过50个字符")
+    @Schema(description = "资源类型", example = "article", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String resource;
+
+    @NotBlank(message = "操作类型不能为空")
+    @Size(max = 50, message = "操作类型长度不能超过50个字符")
+    @Schema(description = "操作类型", example = "view", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String action;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/enums/PermissionAction.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/enums/PermissionAction.java
@@ -1,0 +1,36 @@
+package com.kisesaki.blog.auth.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 权限操作类型枚举
+ * 
+ * @author KiseSaki
+ */
+@Getter
+@AllArgsConstructor
+public enum PermissionAction {
+    VIEW("view", "查看"),
+    CREATE("create", "创建"),
+    EDIT("edit", "编辑"),
+    DELETE("delete", "删除"),
+    MANAGE("manage", "管理"),
+    PUBLISH("publish", "发布"),
+    BAN("ban", "封禁"),
+    UNBAN("unban", "解封"),
+    ASSIGN("assign", "分配"),
+    MODERATE("moderate", "审核"),
+    UPLOAD("upload", "上传"),
+    SEND("send", "发送"),
+    MONITOR("monitor", "监控"),
+    BACKUP("backup", "备份"),
+    RESTORE("restore", "恢复"),
+    EXPORT("export", "导出"),
+    ACTION("action", "处理"),
+    OWN("own", "自己的"),
+    ALL("all", "所有");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/enums/PermissionResource.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/enums/PermissionResource.java
@@ -1,0 +1,37 @@
+package com.kisesaki.blog.auth.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 权限资源类型枚举
+ * 
+ * @author KiseSaki
+ */
+@Getter
+@AllArgsConstructor
+public enum PermissionResource {
+    POST("post", "文章"),
+    USER("user", "用户"),
+    ROLE("role", "角色"),
+    PERMISSION("permission", "权限"),
+    CATEGORY("category", "分类"),
+    TAG("tag", "标签"),
+    COMMENT("comment", "评论"),
+    FILE("file", "文件"),
+    ANALYTICS("analytics", "分析"),
+    STATS("stats", "统计"),
+    NOTIFICATION("notification", "通知"),
+    SUBSCRIPTION("subscription", "订阅"),
+    NEWSLETTER("newsletter", "新闻通讯"),
+    SYSTEM("system", "系统"),
+    SEO("seo", "SEO"),
+    REDIRECT("redirect", "重定向"),
+    AUDIT("audit", "审计"),
+    REPORT("report", "举报"),
+    SEARCH("search", "搜索"),
+    TOKEN("token", "令牌");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/mapper/PermissionMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/mapper/PermissionMapper.java
@@ -1,11 +1,6 @@
 package com.kisesaki.blog.auth.mapper;
 
-import java.util.List;
-import java.util.Optional;
-
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
-import org.apache.ibatis.annotations.Select;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.kisesaki.blog.auth.entity.Permission;
@@ -17,72 +12,4 @@ import com.kisesaki.blog.auth.entity.Permission;
  */
 @Mapper
 public interface PermissionMapper extends BaseMapper<Permission> {
-
-    /**
-     * 根据权限名称查找权限
-     * 
-     * @param name 权限名称
-     * @return 权限信息
-     */
-    @Select("SELECT * FROM permissions WHERE name = #{name}")
-    Optional<Permission> findByName(@Param("name") String name);
-
-    /**
-     * 检查权限名称是否存在
-     * 
-     * @param name 权限名称
-     * @return 是否存在
-     */
-    @Select("SELECT COUNT(*) > 0 FROM permissions WHERE name = #{name}")
-    boolean existsByName(@Param("name") String name);
-
-    /**
-     * 根据角色ID查找角色的所有权限
-     * 
-     * @param roleId 角色ID
-     * @return 权限列表
-     */
-    @Select("SELECT p.* FROM permissions p " +
-            "INNER JOIN role_permissions rp ON p.id = rp.permission_id " +
-            "WHERE rp.role_id = #{roleId}")
-    List<Permission> findByRoleId(@Param("roleId") Long roleId);
-
-    /**
-     * 根据用户ID查找用户的所有权限（通过角色关联）
-     * 
-     * @param userId 用户ID
-     * @return 权限列表
-     */
-    @Select("SELECT DISTINCT p.* FROM permissions p " +
-            "INNER JOIN role_permissions rp ON p.id = rp.permission_id " +
-            "INNER JOIN user_roles ur ON rp.role_id = ur.role_id " +
-            "WHERE ur.user_id = #{userId}")
-    List<Permission> findByUserId(@Param("userId") Long userId);
-
-    /**
-     * 根据资源类型查找权限
-     * 
-     * @param resource 资源类型
-     * @return 权限列表
-     */
-    @Select("SELECT * FROM permissions WHERE resource = #{resource} ORDER BY action ASC")
-    List<Permission> findByResource(@Param("resource") String resource);
-
-    /**
-     * 获取所有可用权限
-     * 
-     * @return 权限列表
-     */
-    @Select("SELECT * FROM permissions ORDER BY resource ASC, action ASC")
-    List<Permission> findAllPermissions();
-
-    /**
-     * 根据资源和操作查找权限
-     * 
-     * @param resource 资源类型
-     * @param action   操作类型
-     * @return 权限信息
-     */
-    @Select("SELECT * FROM permissions WHERE resource = #{resource} AND action = #{action}")
-    Optional<Permission> findByResourceAndAction(@Param("resource") String resource, @Param("action") String action);
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/AuthService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/AuthService.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.auth;
+package com.kisesaki.blog.auth.service;
 
 import java.time.LocalDateTime;
 import java.util.Map;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/AuthService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/AuthService.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import com.kisesaki.blog.auth.dto.request.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -19,7 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kisesaki.blog.auth.dto.DeviceInfo;
-import com.kisesaki.blog.auth.dto.response.LoginResponseDto;
+import com.kisesaki.blog.auth.dto.auth.request.*;
+import com.kisesaki.blog.auth.dto.auth.response.LoginResponseDto;
 import com.kisesaki.blog.auth.event.UserRegistrationEvent;
 import com.kisesaki.blog.auth.security.jwt.DeviceFingerprintService;
 import com.kisesaki.blog.auth.security.jwt.JwtTokenProvider;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
@@ -1,0 +1,16 @@
+package com.kisesaki.blog.auth.service;
+
+import org.springframework.stereotype.Service;
+
+import com.kisesaki.blog.auth.mapper.PermissionMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PermissionService {
+
+    private final PermissionMapper permissionMapper;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
@@ -1,17 +1,20 @@
 package com.kisesaki.blog.auth.service;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.kisesaki.blog.auth.dto.permission.PermissionCreateRequest;
 import com.kisesaki.blog.auth.dto.permission.PermissionDetailResponse;
 import com.kisesaki.blog.auth.dto.permission.PermissionListParams;
 import com.kisesaki.blog.auth.dto.permission.PermissionListResponse;
 import com.kisesaki.blog.auth.entity.Permission;
 import com.kisesaki.blog.auth.mapper.PermissionMapper;
 import com.kisesaki.blog.common.dto.PageResponse;
+import com.kisesaki.blog.common.exception.BusinessException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -95,5 +98,29 @@ public class PermissionService {
             response.setCreatedAt(permission.getCreatedAt());
         }
         return response;
+    }
+
+    /**
+     * 创建权限
+     * 
+     * @param request 创建请求参数
+     */
+    public void createPermission(PermissionCreateRequest request) {
+        Permission existing = permissionMapper.selectOne(new LambdaQueryWrapper<Permission>()
+                .eq(Permission::getName, request.getName())
+                .eq(Permission::getResource, request.getResource())
+                .eq(Permission::getAction, request.getAction()));
+
+        if (existing != null) {
+            throw BusinessException.paramError("权限已存在");
+        }
+
+        Permission permission = new Permission();
+        permission.setName(request.getName());
+        permission.setDescription(request.getDescription());
+        permission.setResource(request.getResource());
+        permission.setAction(request.getAction());
+        permission.setCreatedAt(OffsetDateTime.now());
+        permissionMapper.insert(permission);
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.kisesaki.blog.auth.dto.permission.PermissionDetailResponse;
 import com.kisesaki.blog.auth.dto.permission.PermissionListParams;
 import com.kisesaki.blog.auth.dto.permission.PermissionListResponse;
 import com.kisesaki.blog.auth.entity.Permission;
@@ -71,5 +72,28 @@ public class PermissionService {
         dtoPage.setRecords(responseList);
 
         return PageResponse.of(dtoPage);
+    }
+
+    /**
+     * 根据ID获取权限详情
+     * 
+     * @param id 权限ID
+     * @return 权限详情，若不存在则返回null
+     */
+    public PermissionDetailResponse getPermissionById(Long id) {
+        Permission permission = permissionMapper.selectById(id);
+        if (permission == null) {
+            return null;
+        }
+        PermissionDetailResponse response = new PermissionDetailResponse();
+        response.setId(permission.getId());
+        response.setName(permission.getName());
+        response.setDescription(permission.getDescription());
+        response.setResource(permission.getResource());
+        response.setAction(permission.getAction());
+        if (permission.getCreatedAt() != null) {
+            response.setCreatedAt(permission.getCreatedAt());
+        }
+        return response;
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
@@ -1,6 +1,7 @@
 package com.kisesaki.blog.auth.service;
 
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -11,7 +12,11 @@ import com.kisesaki.blog.auth.dto.permission.PermissionCreateRequest;
 import com.kisesaki.blog.auth.dto.permission.PermissionDetailResponse;
 import com.kisesaki.blog.auth.dto.permission.PermissionListParams;
 import com.kisesaki.blog.auth.dto.permission.PermissionListResponse;
+import com.kisesaki.blog.auth.dto.permission.PermissionOptionResponse;
+import com.kisesaki.blog.auth.dto.permission.PermissionUpdateRequest;
 import com.kisesaki.blog.auth.entity.Permission;
+import com.kisesaki.blog.auth.enums.PermissionAction;
+import com.kisesaki.blog.auth.enums.PermissionResource;
 import com.kisesaki.blog.auth.mapper.PermissionMapper;
 import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.common.exception.BusinessException;
@@ -122,5 +127,77 @@ public class PermissionService {
         permission.setAction(request.getAction());
         permission.setCreatedAt(OffsetDateTime.now());
         permissionMapper.insert(permission);
+    }
+
+    /**
+     * 更新权限
+     * 
+     * @param id      权限ID
+     * @param request 更新请求参数
+     */
+    public void updatePermission(Long id, PermissionUpdateRequest request) {
+        Permission existing = permissionMapper.selectById(id);
+        if (existing == null) {
+            throw BusinessException.notFound("权限不存在");
+        }
+
+        // 检查权限名称、资源、操作的组合是否已被其他权限使用
+        Permission duplicate = permissionMapper.selectOne(new LambdaQueryWrapper<Permission>()
+                .eq(Permission::getName, request.getName())
+                .eq(Permission::getResource, request.getResource())
+                .eq(Permission::getAction, request.getAction())
+                .ne(Permission::getId, id));
+
+        if (duplicate != null) {
+            throw BusinessException.paramError("权限组合已存在");
+        }
+
+        existing.setName(request.getName());
+        existing.setDescription(request.getDescription());
+        existing.setResource(request.getResource());
+        existing.setAction(request.getAction());
+
+        permissionMapper.updateById(existing);
+        log.info("权限已更新: id={}, name={}", id, request.getName());
+    }
+
+    /**
+     * 删除权限
+     * 
+     * @param id 权限ID
+     */
+    public void deletePermission(Long id) {
+        Permission existing = permissionMapper.selectById(id);
+        if (existing == null) {
+            throw BusinessException.notFound("权限不存在");
+        }
+
+        // TODO: 检查权限是否被角色引用，如果被引用则不允许删除
+        // 这部分需要在实现角色权限关联表后进行
+
+        permissionMapper.deleteById(id);
+        log.info("权限已删除: id={}, name={}", id, existing.getName());
+    }
+
+    /**
+     * 获取权限资源类型列表
+     * 
+     * @return 资源类型列表
+     */
+    public List<PermissionOptionResponse> getPermissionResources() {
+        return Arrays.stream(PermissionResource.values())
+                .map(resource -> new PermissionOptionResponse(resource.getCode(), resource.getDescription()))
+                .toList();
+    }
+
+    /**
+     * 获取权限操作类型列表
+     * 
+     * @return 操作类型列表
+     */
+    public List<PermissionOptionResponse> getPermissionActions() {
+        return Arrays.stream(PermissionAction.values())
+                .map(action -> new PermissionOptionResponse(action.getCode(), action.getDescription()))
+                .toList();
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
@@ -22,6 +22,12 @@ public class PermissionService {
 
     private final PermissionMapper permissionMapper;
 
+    /**
+     * 获取权限列表
+     * 
+     * @param params 查询参数
+     * @return 分页结果
+     */
     public PageResponse<PermissionListResponse> getPermissionsList(PermissionListParams params) {
         LambdaQueryWrapper<Permission> queryWrapper = new LambdaQueryWrapper<Permission>();
         if (params.getName() != null) {

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
@@ -1,8 +1,16 @@
 package com.kisesaki.blog.auth.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.kisesaki.blog.auth.dto.permission.PermissionListParams;
+import com.kisesaki.blog.auth.dto.permission.PermissionListResponse;
+import com.kisesaki.blog.auth.entity.Permission;
 import com.kisesaki.blog.auth.mapper.PermissionMapper;
+import com.kisesaki.blog.common.dto.PageResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,4 +21,49 @@ import lombok.extern.slf4j.Slf4j;
 public class PermissionService {
 
     private final PermissionMapper permissionMapper;
+
+    public PageResponse<PermissionListResponse> getPermissionsList(PermissionListParams params) {
+        LambdaQueryWrapper<Permission> queryWrapper = new LambdaQueryWrapper<Permission>();
+        if (params.getName() != null) {
+            queryWrapper.eq(Permission::getName, params.getName());
+        }
+        if (params.getResource() != null) {
+            queryWrapper.eq(Permission::getResource, params.getResource());
+        }
+        if (params.getAction() != null) {
+            queryWrapper.eq(Permission::getAction, params.getAction());
+        }
+
+        // 先获取数量
+        long totalCount = permissionMapper.selectCount(queryWrapper);
+
+        if (totalCount == 0) {
+            return PageResponse.of(List.of(), 0L, params.getPageable());
+        }
+
+        // 构建分页对象
+        Page<Permission> page = new Page<>(params.getPageable().getCurrentPage(),
+                params.getPageable().getPageSize());
+        Page<Permission> result = permissionMapper.selectPage(page, queryWrapper);
+
+        List<PermissionListResponse> responseList = result.getRecords().stream().map(permission -> {
+            PermissionListResponse response = new PermissionListResponse();
+            response.setId(permission.getId());
+            response.setName(permission.getName());
+            response.setDescription(permission.getDescription());
+            response.setResource(permission.getResource());
+            response.setAction(permission.getAction());
+            if (permission.getCreatedAt() != null) {
+                response.setCreatedAt(permission.getCreatedAt());
+            }
+            return response;
+        }).toList();
+
+        // 构造 DTO 分页对象并返回
+        Page<PermissionListResponse> dtoPage = new Page<>(result.getCurrent(), result.getSize());
+        dtoPage.setTotal(totalCount);
+        dtoPage.setRecords(responseList);
+
+        return PageResponse.of(dtoPage);
+    }
 }

--- a/backend/blog-backend/src/main/resources/db/migration/V6__insert_initial_permissions.sql
+++ b/backend/blog-backend/src/main/resources/db/migration/V6__insert_initial_permissions.sql
@@ -1,0 +1,515 @@
+-- V6__insert_initial_permissions.sql
+-- Flyway migration: Insert initial permission data
+-- Generated based on requirement specification
+
+-- 文章相关权限 (post:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'post:create',
+        '创建文章权限',
+        'post',
+        'create'
+    ),
+    (
+        'post:edit:own',
+        '编辑自己文章的权限',
+        'post',
+        'edit:own'
+    ),
+    (
+        'post:edit:all',
+        '编辑所有文章的权限',
+        'post',
+        'edit:all'
+    ),
+    (
+        'post:delete:own',
+        '删除自己文章的权限',
+        'post',
+        'delete:own'
+    ),
+    (
+        'post:delete:all',
+        '删除所有文章的权限',
+        'post',
+        'delete:all'
+    ),
+    (
+        'post:publish',
+        '发布文章权限',
+        'post',
+        'publish'
+    ),
+    (
+        'post:manage',
+        '文章管理权限（包括设置精选、置顶等）',
+        'post',
+        'manage'
+    ),
+    (
+        'post:revision:view',
+        '查看文章版本历史权限',
+        'post',
+        'revision:view'
+    ),
+    (
+        'post:revision:restore',
+        '恢复文章版本权限',
+        'post',
+        'revision:restore'
+    );
+
+-- 用户相关权限 (user:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'user:manage',
+        '用户管理权限',
+        'user',
+        'manage'
+    ),
+    (
+        'user:ban',
+        '封禁用户权限',
+        'user',
+        'ban'
+    ),
+    (
+        'user:unban',
+        '解封用户权限',
+        'user',
+        'unban'
+    );
+
+-- 角色权限管理 (role:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'role:view',
+        '查看角色权限',
+        'role',
+        'view'
+    ),
+    (
+        'role:create',
+        '创建角色权限',
+        'role',
+        'create'
+    ),
+    (
+        'role:edit',
+        '编辑角色权限',
+        'role',
+        'edit'
+    ),
+    (
+        'role:delete',
+        '删除角色权限',
+        'role',
+        'delete'
+    ),
+    (
+        'role:assign',
+        '分配角色权限',
+        'role',
+        'assign'
+    );
+
+-- 权限管理 (permission:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'permission:view',
+        '查看权限权限',
+        'permission',
+        'view'
+    ),
+    (
+        'permission:create',
+        '创建权限权限',
+        'permission',
+        'create'
+    ),
+    (
+        'permission:edit',
+        '编辑权限权限',
+        'permission',
+        'edit'
+    ),
+    (
+        'permission:delete',
+        '删除权限权限',
+        'permission',
+        'delete'
+    );
+
+-- 分类管理权限 (category:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'category:view',
+        '查看分类权限',
+        'category',
+        'view'
+    ),
+    (
+        'category:create',
+        '创建分类权限',
+        'category',
+        'create'
+    ),
+    (
+        'category:edit',
+        '编辑分类权限',
+        'category',
+        'edit'
+    ),
+    (
+        'category:delete',
+        '删除分类权限',
+        'category',
+        'delete'
+    );
+
+-- 标签管理权限 (tag:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'tag:create',
+        '创建标签权限',
+        'tag',
+        'create'
+    ),
+    (
+        'tag:edit',
+        '编辑标签权限',
+        'tag',
+        'edit'
+    ),
+    (
+        'tag:delete',
+        '删除标签权限',
+        'tag',
+        'delete'
+    ),
+    (
+        'tag:manage',
+        '标签管理权限（包括审核）',
+        'tag',
+        'manage'
+    );
+
+-- 评论相关权限 (comment:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'comment:create',
+        '发表评论权限',
+        'comment',
+        'create'
+    ),
+    (
+        'comment:manage',
+        '评论管理权限',
+        'comment',
+        'manage'
+    ),
+    (
+        'comment:moderate',
+        '评论审核权限',
+        'comment',
+        'moderate'
+    ),
+    (
+        'comment:delete',
+        '删除评论权限',
+        'comment',
+        'delete'
+    );
+
+-- 文件管理权限 (file:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'file:upload',
+        '文件上传权限',
+        'file',
+        'upload'
+    ),
+    (
+        'file:manage',
+        '文件管理权限',
+        'file',
+        'manage'
+    ),
+    (
+        'file:delete',
+        '文件删除权限',
+        'file',
+        'delete'
+    );
+
+-- 统计分析权限 (analytics:* & stats:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'analytics:view',
+        '查看统计数据权限',
+        'analytics',
+        'view'
+    ),
+    (
+        'stats:view',
+        '查看统计信息权限',
+        'stats',
+        'view'
+    );
+
+-- 通知权限 (notification:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'notification:send',
+        '发送通知权限',
+        'notification',
+        'send'
+    ),
+    (
+        'notification:manage',
+        '通知管理权限',
+        'notification',
+        'manage'
+    );
+
+-- 订阅权限 (subscription:* & newsletter:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'subscription:manage',
+        '订阅管理权限',
+        'subscription',
+        'manage'
+    ),
+    (
+        'newsletter:send',
+        '发送新闻通讯权限',
+        'newsletter',
+        'send'
+    ),
+    (
+        'newsletter:manage',
+        '新闻通讯管理权限',
+        'newsletter',
+        'manage'
+    );
+
+-- 系统管理权限 (system:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'system:manage',
+        '系统管理权限',
+        'system',
+        'manage'
+    ),
+    (
+        'system:monitor',
+        '系统监控权限',
+        'system',
+        'monitor'
+    ),
+    (
+        'system:backup',
+        '系统备份权限',
+        'system',
+        'backup'
+    ),
+    (
+        'system:restore',
+        '系统恢复权限',
+        'system',
+        'restore'
+    );
+
+-- SEO管理权限 (seo:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'seo:manage',
+        'SEO管理权限',
+        'seo',
+        'manage'
+    );
+
+-- 重定向管理权限 (redirect:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'redirect:manage',
+        '重定向管理权限',
+        'redirect',
+        'manage'
+    ),
+    (
+        'redirect:create',
+        '创建重定向权限',
+        'redirect',
+        'create'
+    ),
+    (
+        'redirect:edit',
+        '编辑重定向权限',
+        'redirect',
+        'edit'
+    ),
+    (
+        'redirect:delete',
+        '删除重定向权限',
+        'redirect',
+        'delete'
+    );
+
+-- 审计权限 (audit:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'audit:view',
+        '查看审计日志权限',
+        'audit',
+        'view'
+    ),
+    (
+        'audit:export',
+        '导出审计日志权限',
+        'audit',
+        'export'
+    );
+
+-- 举报管理权限 (report:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'report:manage',
+        '举报管理权限',
+        'report',
+        'manage'
+    ),
+    (
+        'report:action',
+        '举报处理权限',
+        'report',
+        'action'
+    );
+
+-- 搜索管理权限 (search:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'search:manage',
+        '搜索管理权限',
+        'search',
+        'manage'
+    );
+
+-- API令牌权限 (token:*)
+INSERT INTO
+    permissions (
+        name,
+        description,
+        resource,
+        "action"
+    )
+VALUES (
+        'token:manage',
+        'API令牌管理权限',
+        'token',
+        'manage'
+    );
+
+-- End of migration


### PR DESCRIPTION
### **描述 (Description)**n+
本次 Pull Request 的主要目标：

- 实现完整的后端权限管理功能（包括权限的增删改查 API）。
- 提供用于初始化系统权限的数据库迁移/种子脚本以便快速可用的默认权限集。

此改动涉及的模块：

- `backend/blog-backend/src/main/java/.../permission`（Controller/Service/DTO/Mapper/Enum 等实现）
- `backend/blog-backend/src/main/resources/db/migration` 或 `backend/blog-backend/src/main/resources`（初始权限数据迁移脚本/种子）

---

### **主要变更 (Changes)**

- **新增**: 
  - 权限管理相关 Controller、Service、DTO、Mapper、Enum（资源类型/操作类型）
  - 权限创建、更新、删除、按 ID 查询、列表查询接口（完整 CRUD）
  - 初始权限数据迁移/种子脚本（包含文章/用户/角色/权限等默认权限）
- **修改**: 
  - 为获取权限列表的接口添加了参数校验与 DTO 完善
  - 更新或调整若干 auth/permission 相关的包结构（移动 DTO、Service/Controller 到对应目录）
  - 补充接口注释与文档注释以便 API 文档生成
- **删除**: 
  - 删除了 AI 生成 Mapper 中不需要的方法（改用更简洁的 Mapper 实现）
- **优化/重构**: 
  - 权限创建接口加入重复检查与请求参数校验
  - 完成权限管理 API 的异常处理与返回规范，使其符合统一响应格式

---

### **影响范围 (Impact)**

- 影响的功能/模块：后台管理模块的权限管理相关接口及与之相关的鉴权/授权逻辑；可能会影响管理角色对资源的访问控制。
- 是否涉及数据库/接口/配置变更：是。包含初始权限数据迁移/种子脚本，部署后需要执行或在应用启动时生效；新增/变更的接口需对外说明。
- 是否存在向下兼容性风险：低 — 新增接口与 DB 种子为向后兼容形式，但若前端或第三方直接依赖旧的权限数据结构（字段名/枚举）则可能需要同步更新；建议在发布时通知运维执行数据库迁移并在 QA 环境验证。

---

### 提交摘要（相对于 `dev` 分支的变更）

- 4840e2c — ✨ feat(permission): 添加初始权限数据迁移脚本
- eb87d39 — ✨ feat(permission): 完善权限管理API接口（新增 PUT/DELETE/资源/操作列表接口与枚举）
- c9d01b3 — ✨ feat(permission): 添加权限创建接口及相关逻辑（参数校验、重复检查）
- d1e3770 — ✨ feat(permission): 更新获取权限列表接口，添加参数校验
- e437eea — ✨ feat(permission): 添加根据ID获取权限详情的接口及相关逻辑
- ac52c3b — ✨ feat(permission): 添加权限列表查询接口及相关DTO
- a33dd43 / 5477787 — ✨ feat(permission): 初始化 permission 的控制器和服务类
- 4304a2d 等 — 若干重构（移动 auth DTO、删除 AI 生成 Mapper 的多余方法等）
