### PR TITLE
🐞 fix:(permission): 修改权限列表查询条件为模糊匹配

### DIFF
--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/PermissionService.java
@@ -40,7 +40,7 @@ public class PermissionService {
     public PageResponse<PermissionListResponse> getPermissionsList(PermissionListParams params) {
         LambdaQueryWrapper<Permission> queryWrapper = new LambdaQueryWrapper<Permission>();
         if (params.getName() != null) {
-            queryWrapper.eq(Permission::getName, params.getName());
+            queryWrapper.like(Permission::getName, params.getName());
         }
         if (params.getResource() != null) {
             queryWrapper.eq(Permission::getResource, params.getResource());


### PR DESCRIPTION
将获取权限列表的方法中的名称查询条件从等于修改为模糊匹配，以支持更灵活的查询。