### PR TITLE
✨feat(content/tag): 完成标签模块

### DIFF
--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/common/util/PageQueryUtils.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/common/util/PageQueryUtils.java
@@ -50,32 +50,26 @@ public class PageQueryUtils {
             PageableParams pageable,
             Function<T, R> converter) {
 
-        // 根据 includeTotal 参数决定是否计算总数
-        Long totalCount = null;
-        if (pageable.getIncludeTotal()) {
-            totalCount = mapper.selectCount(queryWrapper);
-            if (totalCount == 0) {
-                return PageResponse.of(List.of(), totalCount, pageable);
-            }
-        }
-
         // 构建分页对象
         Page<T> page = new Page<>(pageable.getCurrentPage(), pageable.getPageSize());
+
+        // 根据 includeTotal 参数决定是否需要计算总数
+        if (!pageable.getIncludeTotal()) {
+            page.setSearchCount(false); // 禁用自动计算总数
+        }
 
         // 执行分页查询
         Page<T> result = mapper.selectPage(page, queryWrapper);
 
-        // 如果没有预先计算总数，则从分页结果中获取
-        if (totalCount == null) {
-            totalCount = result.getTotal();
-        }
+        // 获取总数
+        Long totalCount = pageable.getIncludeTotal() ? result.getTotal() : null;
 
         // 转换成响应对象
         List<R> responseList = result.getRecords().stream()
                 .map(converter)
                 .toList();
 
-        return PageResponse.of(responseList, totalCount, pageable);
+        return PageResponse.of(responseList, totalCount != null ? totalCount : 0L, pageable);
     }
 
     /**
@@ -158,7 +152,6 @@ public class PageQueryUtils {
 
         /**
          * 设置默认排序字段
-         * 设置当没有指定排序字段时使用的默认排序
          */
         public SortBuilder<T> defaultSort(SFunction<T, ?> defaultSortField, boolean descending) {
             this.defaultSortField = defaultSortField;
@@ -170,13 +163,10 @@ public class PageQueryUtils {
          * 添加排序字段映射
          */
         public SortBuilder<T> addSortField(String fieldName, SFunction<T, ?> fieldFunction) {
-            // 从分页参数中获取排序字段名
             String sortField = pageable.getSortField();
-            // 获取排序方向
             boolean isDescending = pageable.isDescending();
 
             if (sortField != null && sortField.equals(fieldName)) {
-                // 如果当前字段匹配，则应用排序
                 queryWrapper.orderBy(true, !isDescending, fieldFunction);
                 return this;
             }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/common/util/PageQueryUtils.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/common/util/PageQueryUtils.java
@@ -1,0 +1,216 @@
+package com.kisesaki.blog.common.util;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.function.Function;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.toolkit.support.SFunction;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.kisesaki.blog.common.dto.PageResponse;
+import com.kisesaki.blog.common.dto.PageableParams;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 分页查询工具类
+ * 
+ * <p>
+ * 提供通用的分页查询功能，包括：
+ * <ul>
+ * <li>时间范围查询支持</li>
+ * <li>排序规则应用</li>
+ * <li>性能优化（可选的总数计算）</li>
+ * <li>类型安全的查询构建</li>
+ * </ul>
+ * 
+ * @author KiseSaki
+ * @since 1.0.0
+ */
+@Slf4j
+public class PageQueryUtils {
+
+    /**
+     * 执行分页查询
+     * 
+     * @param <T>          实体类型
+     * @param <R>          响应类型
+     * @param mapper       MyBatis-Plus Mapper
+     * @param queryWrapper 查询条件构建器
+     * @param pageable     分页参数
+     * @param converter    实体到响应对象的转换器
+     * @return 分页响应结果
+     */
+    public static <T, R> PageResponse<R> executePageQuery(
+            BaseMapper<T> mapper,
+            LambdaQueryWrapper<T> queryWrapper,
+            PageableParams pageable,
+            Function<T, R> converter) {
+
+        // 根据 includeTotal 参数决定是否计算总数
+        Long totalCount = null;
+        if (pageable.getIncludeTotal()) {
+            totalCount = mapper.selectCount(queryWrapper);
+            if (totalCount == 0) {
+                return PageResponse.of(List.of(), totalCount, pageable);
+            }
+        }
+
+        // 构建分页对象
+        Page<T> page = new Page<>(pageable.getCurrentPage(), pageable.getPageSize());
+
+        // 执行分页查询
+        Page<T> result = mapper.selectPage(page, queryWrapper);
+
+        // 如果没有预先计算总数，则从分页结果中获取
+        if (totalCount == null) {
+            totalCount = result.getTotal();
+        }
+
+        // 转换成响应对象
+        List<R> responseList = result.getRecords().stream()
+                .map(converter)
+                .toList();
+
+        return PageResponse.of(responseList, totalCount, pageable);
+    }
+
+    /**
+     * 应用时间范围查询条件
+     * 
+     * @param <T>               实体类型
+     * @param queryWrapper      查询条件构建器
+     * @param pageable          分页参数
+     * @param createdAtFunction 创建时间字段的函数引用
+     */
+    public static <T> void applyTimeRangeConditions(
+            LambdaQueryWrapper<T> queryWrapper,
+            PageableParams pageable,
+            SFunction<T, OffsetDateTime> createdAtFunction) {
+
+        // 时间范围查询 - 转换为 OffsetDateTime
+        if (pageable.getStartTime() != null) {
+            OffsetDateTime startTime = convertToOffsetDateTime(pageable.getStartTime());
+            queryWrapper.ge(createdAtFunction, startTime);
+        }
+
+        if (pageable.getEndTime() != null) {
+            OffsetDateTime endTime = convertToOffsetDateTime(pageable.getEndTime());
+            queryWrapper.le(createdAtFunction, endTime);
+        }
+
+        // 指定日期查询 - 转换为 OffsetDateTime 范围
+        if (pageable.getDate() != null) {
+            OffsetDateTime dayStart = pageable.getDate().atStartOfDay().atOffset(ZoneOffset.UTC);
+            OffsetDateTime dayEnd = pageable.getDate().atTime(23, 59, 59).atOffset(ZoneOffset.UTC);
+            queryWrapper.between(createdAtFunction, dayStart, dayEnd);
+        }
+    }
+
+    /**
+     * 应用时间范围查询条件（LocalDateTime 版本）
+     * 
+     * @param <T>               实体类型
+     * @param queryWrapper      查询条件构建器
+     * @param pageable          分页参数
+     * @param createdAtFunction 创建时间字段的函数引用
+     */
+    public static <T> void applyTimeRangeConditionsForLocalDateTime(
+            LambdaQueryWrapper<T> queryWrapper,
+            PageableParams pageable,
+            SFunction<T, LocalDateTime> createdAtFunction) {
+
+        // 时间范围查询
+        if (pageable.getStartTime() != null) {
+            queryWrapper.ge(createdAtFunction, pageable.getStartTime());
+        }
+
+        if (pageable.getEndTime() != null) {
+            queryWrapper.le(createdAtFunction, pageable.getEndTime());
+        }
+
+        // 指定日期查询
+        if (pageable.getDate() != null) {
+            LocalDateTime dayStart = pageable.getDate().atStartOfDay();
+            LocalDateTime dayEnd = pageable.getDate().atTime(23, 59, 59);
+            queryWrapper.between(createdAtFunction, dayStart, dayEnd);
+        }
+    }
+
+    /**
+     * 应用排序规则的构建器
+     * 
+     * @param <T> 实体类型
+     */
+    public static class SortBuilder<T> {
+        private final LambdaQueryWrapper<T> queryWrapper;
+        private final PageableParams pageable;
+        private SFunction<T, ?> defaultSortField;
+        private boolean defaultDescending = true;
+
+        public SortBuilder(LambdaQueryWrapper<T> queryWrapper, PageableParams pageable) {
+            this.queryWrapper = queryWrapper;
+            this.pageable = pageable;
+        }
+
+        /**
+         * 设置默认排序字段
+         * 设置当没有指定排序字段时使用的默认排序
+         */
+        public SortBuilder<T> defaultSort(SFunction<T, ?> defaultSortField, boolean descending) {
+            this.defaultSortField = defaultSortField;
+            this.defaultDescending = descending;
+            return this;
+        }
+
+        /**
+         * 添加排序字段映射
+         */
+        public SortBuilder<T> addSortField(String fieldName, SFunction<T, ?> fieldFunction) {
+            // 从分页参数中获取排序字段名
+            String sortField = pageable.getSortField();
+            // 获取排序方向
+            boolean isDescending = pageable.isDescending();
+
+            if (sortField != null && sortField.equals(fieldName)) {
+                // 如果当前字段匹配，则应用排序
+                queryWrapper.orderBy(true, !isDescending, fieldFunction);
+                return this;
+            }
+            return this;
+        }
+
+        /**
+         * 应用排序
+         */
+        public void apply() {
+            String sortField = pageable.getSortField();
+
+            // 如果没有找到匹配的排序字段，使用默认排序
+            if (sortField == null && defaultSortField != null) {
+                if (defaultDescending) {
+                    queryWrapper.orderByDesc(defaultSortField);
+                } else {
+                    queryWrapper.orderByAsc(defaultSortField);
+                }
+            }
+        }
+    }
+
+    /**
+     * 创建排序构建器
+     */
+    public static <T> SortBuilder<T> createSortBuilder(LambdaQueryWrapper<T> queryWrapper, PageableParams pageable) {
+        return new SortBuilder<>(queryWrapper, pageable);
+    }
+
+    /**
+     * 转换 LocalDateTime 到 OffsetDateTime
+     */
+    private static OffsetDateTime convertToOffsetDateTime(LocalDateTime localDateTime) {
+        return localDateTime.atOffset(ZoneOffset.UTC);
+    }
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/common/util/SlugUtils.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/common/util/SlugUtils.java
@@ -1,0 +1,75 @@
+package com.kisesaki.blog.common.util;
+
+import java.text.Normalizer;
+import java.util.regex.Pattern;
+
+/**
+ * URL slug 生成工具类
+ * 用于将标题等文本转换为 URL 友好的 slug
+ * 
+ * @author KiseSaki
+ */
+public class SlugUtils {
+
+    private static final Pattern NON_LATIN = Pattern.compile("[^\\w-]");
+    private static final Pattern WHITESPACE = Pattern.compile("[\\s]");
+    private static final Pattern MULTIPLE_HYPHENS = Pattern.compile("-+");
+
+    /**
+     * 生成 URL slug
+     * 
+     * @param input 输入文本
+     * @return slug
+     */
+    public static String generateSlug(String input) {
+        if (input == null || input.trim().isEmpty()) {
+            return "";
+        }
+
+        String slug = input.trim().toLowerCase();
+        
+        // 处理中文等非ASCII字符，转为拼音或保留
+        slug = transliterate(slug);
+        
+        // 替换空格为连字符
+        slug = WHITESPACE.matcher(slug).replaceAll("-");
+        
+        // 移除非字母数字和连字符的字符
+        slug = NON_LATIN.matcher(slug).replaceAll("");
+        
+        // 合并多个连续的连字符
+        slug = MULTIPLE_HYPHENS.matcher(slug).replaceAll("-");
+        
+        // 移除开头和结尾的连字符
+        slug = slug.replaceAll("^-+|-+$", "");
+        
+        return slug;
+    }
+
+    /**
+     * 音译处理（简化版本）
+     * 这里使用 Unicode 规范化，实际项目中可以集成拼音库
+     */
+    private static String transliterate(String input) {
+        // 使用 Unicode 规范化分解重音字符
+        String normalized = Normalizer.normalize(input, Normalizer.Form.NFD);
+        
+        // 移除重音符号
+        return normalized.replaceAll("\\p{M}", "");
+    }
+
+    /**
+     * 验证 slug 是否有效
+     * 
+     * @param slug 待验证的 slug
+     * @return 是否有效
+     */
+    public static boolean isValidSlug(String slug) {
+        if (slug == null || slug.trim().isEmpty()) {
+            return false;
+        }
+        
+        // slug 只能包含字母、数字和连字符
+        return slug.matches("^[a-z0-9-]+$") && !slug.startsWith("-") && !slug.endsWith("-");
+    }
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostsMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/mapper/PostsMapper.java
@@ -13,6 +13,7 @@ import com.kisesaki.blog.content.post.dto.PostQuery.PublishedPostDetailResponse;
 import com.kisesaki.blog.content.post.dto.PostQuery.PublishedPostListParams;
 import com.kisesaki.blog.content.post.dto.PostQuery.PublishedPostListResponse;
 import com.kisesaki.blog.content.post.entity.Posts;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagPostsParams;
 
 @Mapper
 public interface PostsMapper extends BaseMapper<Posts> {
@@ -154,4 +155,26 @@ public interface PostsMapper extends BaseMapper<Posts> {
          * @return 统计数据
          */
         AdminPostStatsDto.PostStatsResponse getPostStats();
+
+        /**
+         * 分页查询指定标签下的已发布文章
+         *
+         * @param page   分页对象
+         * @param tagId  标签ID
+         * @param params 查询参数
+         * @return 分页结果
+         */
+        Page<PublishedPostListResponse> selectPostsByTagPage(
+                        Page<PublishedPostListResponse> page,
+                        @Param("tagId") Long tagId,
+                        @Param("params") TagPostsParams params);
+
+        /**
+         * 计算指定标签下的已发布文章数量
+         *
+         * @param tagId  标签ID
+         * @param params 查询参数
+         * @return 文章总数
+         */
+        long countPostsByTag(@Param("tagId") Long tagId, @Param("params") TagPostsParams params);
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/service/PostQueryService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/service/PostQueryService.java
@@ -15,6 +15,7 @@ import com.kisesaki.blog.content.post.dto.PostQuery.PublishedPostDetailResponse;
 import com.kisesaki.blog.content.post.dto.PostQuery.PublishedPostListParams;
 import com.kisesaki.blog.content.post.dto.PostQuery.PublishedPostListResponse;
 import com.kisesaki.blog.content.post.mapper.PostsMapper;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagPostsParams;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -137,6 +138,36 @@ public class PostQueryService {
                 false // 禁用自动count查询
         );
         Page<MyPostsListResponse> result = postsMapper.selectMyPostsPage(page, params, userId);
+
+        // 手动设置总数
+        result.setTotal(totalCount);
+
+        return PageResponse.of(result);
+    }
+
+    /**
+     * 按标签获取已发布文章列表
+     *
+     * @param tagId  标签ID
+     * @param params 查询参数
+     * @return 文章列表
+     */
+    public PageResponse<PublishedPostListResponse> selectPostsByTag(Long tagId, TagPostsParams params) {
+        // 手动获取总数
+        long totalCount = postsMapper.countPostsByTag(tagId, params);
+
+        // 如果总数为0，直接返回空结果
+        if (totalCount == 0) {
+            return PageResponse.of(List.of(), 0L, params.getPageable());
+        }
+
+        // 查询分页数据（禁用自动count查询）
+        Page<PublishedPostListResponse> page = new Page<>(
+                params.getPageable().getCurrentPage(),
+                params.getPageable().getPageSize(),
+                false); // 禁用自动count查询
+
+        Page<PublishedPostListResponse> result = postsMapper.selectPostsByTagPage(page, tagId, params);
 
         // 手动设置总数
         result.setTotal(totalCount);

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
@@ -16,8 +16,10 @@ import com.kisesaki.blog.content.tag.dto.TagQuery.TagCloudItem;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListResponse;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagPostsParams;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagSearchItem;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagSearchParams;
+import com.kisesaki.blog.content.post.dto.PostQuery.PublishedPostListResponse;
 import com.kisesaki.blog.content.tag.service.TagQueryService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -83,5 +85,15 @@ public class TagController {
     @PreAuthorize("isAuthenticated()")
     public ApiResponse<List<TagSearchItem>> searchTags(TagSearchParams params) {
         return ResultUtils.success(tagService.searchTags(params));
+    }
+
+    /**
+     * 获取指定标签下的文章列表
+     */
+    @GetMapping("/{tagId}/posts")
+    public ApiResponse<PageResponse<PublishedPostListResponse>> getTagPosts(
+            @PathVariable Long tagId, 
+            TagPostsParams params) {
+        return ResultUtils.success(tagService.getTagPosts(tagId, params));
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
@@ -1,5 +1,7 @@
 package com.kisesaki.blog.content.tag;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.common.dto.ResultUtils;
+import com.kisesaki.blog.content.tag.dto.TagQuery.PopularTagResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListResponse;
@@ -50,5 +53,13 @@ public class TagController {
     @GetMapping("/slug/{slug}")
     public ApiResponse<TagDetailResponse> getTagDetailBySlug(@PathVariable String slug) {
         return ResultUtils.success(tagService.getTagDetailBySlug(slug));
+    }
+
+    /**
+     * 获取热门标签
+     */
+    @GetMapping("/popular")
+    public ApiResponse<List<PopularTagResponse>> getPopularTag() {
+        return ResultUtils.success(tagService.getPopularTag());
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
@@ -1,14 +1,16 @@
 package com.kisesaki.blog.content.tag;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.common.dto.ResultUtils;
-import com.kisesaki.blog.content.tag.dto.TagListParams;
-import com.kisesaki.blog.content.tag.dto.TagListResponse;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagListResponse;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +34,13 @@ public class TagController {
     @GetMapping("")
     public ApiResponse<PageResponse<TagListResponse>> getTagList(TagListParams params) {
         return ResultUtils.success(tagService.getTagList(params));
+    }
+
+    /**
+     * 根据ID获取标签详情
+     */
+    @GetMapping("/{id}")
+    public ApiResponse<TagDetailResponse> getTagDetailById(@PathVariable Long id) {
+        return ResultUtils.success(tagService.getTagDetailById(id));
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
@@ -4,13 +4,19 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.access.prepost.PreAuthorize;
 
+import jakarta.validation.Valid;
+
 import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.common.dto.ResultUtils;
+import com.kisesaki.blog.content.tag.dto.TagCreateRequest;
+import com.kisesaki.blog.content.tag.dto.TagQuery.MyTagResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.PopularTagResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagCloudItem;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
@@ -21,6 +27,8 @@ import com.kisesaki.blog.content.tag.dto.TagQuery.TagSearchItem;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagSearchParams;
 import com.kisesaki.blog.content.post.dto.PostQuery.PublishedPostListResponse;
 import com.kisesaki.blog.content.tag.service.TagQueryService;
+import com.kisesaki.blog.content.tag.service.TagCommandService;
+import com.kisesaki.blog.content.tag.entity.Tags;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +45,7 @@ import lombok.RequiredArgsConstructor;
 public class TagController {
 
     private final TagQueryService tagService;
+    private final TagCommandService tagCommandService;
 
     /**
      * 获取标签列表
@@ -95,5 +104,23 @@ public class TagController {
             @PathVariable Long tagId, 
             TagPostsParams params) {
         return ResultUtils.success(tagService.getTagPosts(tagId, params));
+    }
+
+    /**
+     * 创建新标签（用户创作文章时）
+     */
+    @PostMapping("")
+    @PreAuthorize("hasAuthority('TAG_CREATE')")
+    public ApiResponse<Tags> createTag(@Valid @RequestBody TagCreateRequest request) {
+        return ResultUtils.success(tagCommandService.createTag(request));
+    }
+
+    /**
+     * 获取我创建的标签
+     */
+    @GetMapping("/my")
+    @PreAuthorize("isAuthenticated()")
+    public ApiResponse<PageResponse<MyTagResponse>> getMyTags(TagListParams params) {
+        return ResultUtils.success(tagCommandService.getMyTags(params));
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
@@ -43,4 +43,12 @@ public class TagController {
     public ApiResponse<TagDetailResponse> getTagDetailById(@PathVariable Long id) {
         return ResultUtils.success(tagService.getTagDetailById(id));
     }
+
+    /**
+     * 根据Slug获取标签详情
+     */
+    @GetMapping("/slug/{slug}")
+    public ApiResponse<TagDetailResponse> getTagDetailBySlug(@PathVariable String slug) {
+        return ResultUtils.success(tagService.getTagDetailBySlug(slug));
+    }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
@@ -1,10 +1,21 @@
 package com.kisesaki.blog.content.tag;
 
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
 /**
  * 标签控制器
  * 
  * @author KiseSaki
  */
+@RestController
+@RequestMapping("/tags")
+@Tag(name = "Tag", description = "标签相关接口")
+@RequiredArgsConstructor
 public class TagController {
 
+    private final TagService tagService;
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
@@ -1,7 +1,14 @@
 package com.kisesaki.blog.content.tag;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.kisesaki.blog.common.dto.ApiResponse;
+import com.kisesaki.blog.common.dto.PageResponse;
+import com.kisesaki.blog.common.dto.ResultUtils;
+import com.kisesaki.blog.content.tag.dto.TagListParams;
+import com.kisesaki.blog.content.tag.dto.TagListResponse;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -13,9 +20,17 @@ import lombok.RequiredArgsConstructor;
  */
 @RestController
 @RequestMapping("/tags")
-@Tag(name = "Tag", description = "标签相关接口")
+@Tag(name = "标签", description = "标签相关接口")
 @RequiredArgsConstructor
 public class TagController {
 
     private final TagService tagService;
+
+    /**
+     * 获取标签列表
+     */
+    @GetMapping("")
+    public ApiResponse<PageResponse<TagListResponse>> getTagList(TagListParams params) {
+        return ResultUtils.success(tagService.getTagList(params));
+    }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
@@ -11,6 +11,7 @@ import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.common.dto.ResultUtils;
 import com.kisesaki.blog.content.tag.dto.TagQuery.PopularTagResponse;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagCloudItem;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListResponse;
@@ -61,5 +62,13 @@ public class TagController {
     @GetMapping("/popular")
     public ApiResponse<List<PopularTagResponse>> getPopularTag() {
         return ResultUtils.success(tagService.getPopularTag());
+    }
+
+    /**
+     * 获取标签云
+     */
+    @GetMapping("/cloud")
+    public ApiResponse<List<TagCloudItem>> getTagCloud() {
+        return ResultUtils.success(tagService.getTagCloud());
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
@@ -15,6 +16,8 @@ import com.kisesaki.blog.content.tag.dto.TagQuery.TagCloudItem;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListResponse;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagSearchItem;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagSearchParams;
 import com.kisesaki.blog.content.tag.service.TagQueryService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -71,5 +74,14 @@ public class TagController {
     @GetMapping("/cloud")
     public ApiResponse<List<TagCloudItem>> getTagCloud() {
         return ResultUtils.success(tagService.getTagCloud());
+    }
+
+    /**
+     * 搜索标签（用于创作时的标签建议）
+     */
+    @GetMapping("/search")
+    @PreAuthorize("isAuthenticated()")
+    public ApiResponse<List<TagSearchItem>> searchTags(TagSearchParams params) {
+        return ResultUtils.success(tagService.searchTags(params));
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagController.java
@@ -15,6 +15,7 @@ import com.kisesaki.blog.content.tag.dto.TagQuery.TagCloudItem;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListResponse;
+import com.kisesaki.blog.content.tag.service.TagQueryService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TagController {
 
-    private final TagService tagService;
+    private final TagQueryService tagService;
 
     /**
      * 获取标签列表

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
@@ -2,6 +2,12 @@ package com.kisesaki.blog.content.tag;
 
 import org.springframework.stereotype.Service;
 
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.kisesaki.blog.common.dto.PageResponse;
+import com.kisesaki.blog.common.util.PageQueryUtils;
+import com.kisesaki.blog.content.tag.dto.TagListParams;
+import com.kisesaki.blog.content.tag.dto.TagListResponse;
+import com.kisesaki.blog.content.tag.entity.Tags;
 import com.kisesaki.blog.content.tag.mapper.TagsMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -18,4 +24,62 @@ import lombok.extern.slf4j.Slf4j;
 public class TagService {
 
     private final TagsMapper tagsMapper;
+
+    /**
+     * 获取标签列表
+     * 
+     * @param params 请求参数
+     * @return 标签列表
+     */
+    public PageResponse<TagListResponse> getTagList(TagListParams params) {
+        LambdaQueryWrapper<Tags> queryWrapper = buildQueryWrapper(params);
+
+        // 应用时间范围条件
+        PageQueryUtils.applyTimeRangeConditions(queryWrapper, params.getPageable(), Tags::getCreatedAt);
+
+        // 应用排序规则
+        PageQueryUtils.createSortBuilder(queryWrapper, params.getPageable())
+                .defaultSort(Tags::getCreatedAt, true) // 默认按创建时间倒序
+                .addSortField("id", Tags::getId)
+                .addSortField("name", Tags::getName)
+                .addSortField("postCount", Tags::getPostCount)
+                .addSortField("createdAt", Tags::getCreatedAt)
+                .apply();
+
+        // 执行分页查询
+        return PageQueryUtils.executePageQuery(
+                tagsMapper,
+                queryWrapper,
+                params.getPageable(),
+                this::convertToResponse);
+    }
+
+    /**
+     * 构建查询条件
+     */
+    private LambdaQueryWrapper<Tags> buildQueryWrapper(TagListParams params) {
+        LambdaQueryWrapper<Tags> queryWrapper = new LambdaQueryWrapper<>();
+
+        // 标签名称模糊搜索
+        if (params.getName() != null && !params.getName().isEmpty()) {
+            queryWrapper.like(Tags::getName, params.getName());
+        }
+
+        return queryWrapper;
+    }
+
+    /**
+     * 转换实体为响应对象
+     */
+    private TagListResponse convertToResponse(Tags tag) {
+        TagListResponse response = new TagListResponse();
+        response.setId(tag.getId());
+        response.setName(tag.getName());
+        response.setSlug(tag.getSlug());
+        response.setDescription(tag.getDescription());
+        response.setColor(tag.getColor());
+        response.setPostCount(tag.getPostCount());
+        response.setCreatedAt(tag.getCreatedAt());
+        return response;
+    }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
@@ -8,6 +8,7 @@ import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.common.util.PageQueryUtils;
 import com.kisesaki.blog.content.tag.dto.TagQuery.PopularTagResponse;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagCloudItem;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListResponse;
@@ -101,6 +102,59 @@ public class TagService {
             response.setLastUsedAt(tag.getLastUsedAt());
             return response;
         }).toList();
+    }
+
+    /**
+     * 获取标签云
+     * 
+     * @return 标签云列表，按热度权重排序
+     */
+    public List<TagCloudItem> getTagCloud() {
+        try {
+            // 查询所有标签，按热度权重降序排序，限制数量为50
+            LambdaQueryWrapper<Tags> queryWrapper = new LambdaQueryWrapper<Tags>()
+                    .orderByDesc(Tags::getPopularityScore)
+                    .last("LIMIT 50");
+
+            List<Tags> tags = tagsMapper.selectList(queryWrapper);
+
+            if (tags.isEmpty()) {
+                log.info("标签云查询结果为空");
+                return List.of();
+            }
+
+            // 计算字体权重：基于 popularityScore 或 postCount 映射到 1-10
+            // 找到最大和最小值用于线性映射
+            double maxScore = tags.stream()
+                    .mapToDouble(
+                            tag -> tag.getPopularityScore() != null ? tag.getPopularityScore() : tag.getPostCount())
+                    .max().orElse(1.0);
+            double minScore = tags.stream()
+                    .mapToDouble(
+                            tag -> tag.getPopularityScore() != null ? tag.getPopularityScore() : tag.getPostCount())
+                    .min().orElse(0.0);
+
+            return tags.stream().map(tag -> {
+                TagCloudItem item = new TagCloudItem();
+                item.setId(tag.getId());
+                item.setName(tag.getName());
+                item.setSlug(tag.getSlug());
+                item.setColor(tag.getColor());
+                item.setPostCount(tag.getPostCount());
+                item.setPopularityScore(tag.getPopularityScore());
+
+                // 计算字体权重（1-10），避免除零
+                double score = tag.getPopularityScore() != null ? tag.getPopularityScore() : tag.getPostCount();
+                int fontWeight = (maxScore == minScore) ? 5
+                        : (int) Math.round(1 + 9 * (score - minScore) / (maxScore - minScore));
+                item.setFontWeight(Math.max(1, Math.min(10, fontWeight))); // 确保在 1-10 范围内
+
+                return item;
+            }).toList();
+        } catch (Exception e) {
+            log.error("获取标签云失败", e);
+            throw new RuntimeException("获取标签云失败，请稍后重试");
+        }
     }
 
     /**

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
@@ -66,6 +66,16 @@ public class TagService {
     }
 
     /**
+     * 根据Slug获取标签详情
+     * 
+     * @param slug 标签Slug
+     * @return 标签详情
+     */
+    public TagDetailResponse getTagDetailBySlug(String slug) {
+        return tagsMapper.getTagDetailBySlug(slug);
+    }
+
+    /**
      * 构建查询条件
      */
     private LambdaQueryWrapper<Tags> buildQueryWrapper(TagListParams params) {

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
@@ -5,8 +5,9 @@ import org.springframework.stereotype.Service;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.common.util.PageQueryUtils;
-import com.kisesaki.blog.content.tag.dto.TagListParams;
-import com.kisesaki.blog.content.tag.dto.TagListResponse;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagListResponse;
 import com.kisesaki.blog.content.tag.entity.Tags;
 import com.kisesaki.blog.content.tag.mapper.TagsMapper;
 
@@ -52,6 +53,16 @@ public class TagService {
                 queryWrapper,
                 params.getPageable(),
                 this::convertToResponse);
+    }
+
+    /**
+     * 获取标签详情
+     * 
+     * @param tagId 标签ID
+     * @return 标签详情
+     */
+    public TagDetailResponse getTagDetailById(Long tagId) {
+        return tagsMapper.getTagDetailById(tagId);
     }
 
     /**

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
@@ -1,10 +1,21 @@
 package com.kisesaki.blog.content.tag;
 
+import org.springframework.stereotype.Service;
+
+import com.kisesaki.blog.content.tag.mapper.TagsMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * 标签服务
  * 
  * @author KiseSaki
  */
+@Service
+@RequiredArgsConstructor
+@Slf4j
 public class TagService {
 
+    private final TagsMapper tagsMapper;
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/TagService.java
@@ -1,10 +1,13 @@
 package com.kisesaki.blog.content.tag;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.common.util.PageQueryUtils;
+import com.kisesaki.blog.content.tag.dto.TagQuery.PopularTagResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListResponse;
@@ -73,6 +76,31 @@ public class TagService {
      */
     public TagDetailResponse getTagDetailBySlug(String slug) {
         return tagsMapper.getTagDetailBySlug(slug);
+    }
+
+    /**
+     * 获取热门标签
+     * 
+     * @return 热门标签
+     */
+    public List<PopularTagResponse> getPopularTag() {
+        // 构建查询条件，按热度权重排序，限制返回数量为10
+        LambdaQueryWrapper<Tags> queryWrapper = new LambdaQueryWrapper<Tags>()
+                .orderByDesc(Tags::getPopularityScore).last("LIMIT 10");
+
+        // 执行查询
+        List<Tags> popularTag = tagsMapper.selectList(queryWrapper);
+        return popularTag.stream().map(tag -> {
+            PopularTagResponse response = new PopularTagResponse();
+            response.setId(tag.getId());
+            response.setName(tag.getName());
+            response.setSlug(tag.getSlug());
+            response.setColor(tag.getColor());
+            response.setPostCount(tag.getPostCount());
+            response.setPopularityScore(tag.getPopularityScore());
+            response.setLastUsedAt(tag.getLastUsedAt());
+            return response;
+        }).toList();
     }
 
     /**

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
@@ -1,14 +1,21 @@
 package com.kisesaki.blog.content.tag.controller;
 
-import com.kisesaki.blog.common.util.AuthUtils;
-import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCreateRequest;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
+import com.kisesaki.blog.common.util.AuthUtils;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCreateRequest;
 import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
 import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagUpdateRequest;
 import com.kisesaki.blog.content.tag.service.AdminTagService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,13 +38,25 @@ public class AdminTagController {
         return ApiResponse.success(adminTagService.getAdminTagList(params));
     }
 
-
     /**
      * 创建新标签
      */
     @PostMapping("")
-    public ApiResponse<Long> createAdminTag(@Valid @RequestBody AdminTagCreateRequest request, Authentication authentication) {
+    public ApiResponse<Long> createAdminTag(@Valid @RequestBody AdminTagCreateRequest request,
+            Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         return ApiResponse.success(adminTagService.createAdminTag(request, userId));
+    }
+
+    /**
+     * 更新标签
+     */
+    @PutMapping("/{id}")
+    public ApiResponse<Void> updateAdminTag(@PathVariable("id") Long id,
+            @Valid @RequestBody AdminTagUpdateRequest request,
+            Authentication authentication) {
+        Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
+        adminTagService.updateAdminTag(id, request, userId);
+        return ApiResponse.success();
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
@@ -1,19 +1,35 @@
 package com.kisesaki.blog.content.tag.controller;
 
-import com.kisesaki.blog.content.tag.dto.AdminCommand.*;
+import java.util.List;
+
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.common.util.AuthUtils;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagApprovalRequest;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCleanupResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCreateRequest;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagMergeRequest;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagPendingResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagUnusedResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagUpdateRequest;
 import com.kisesaki.blog.content.tag.service.AdminTagService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/admin/tags")
@@ -36,7 +52,7 @@ public class AdminTagController {
      */
     @PostMapping("")
     public ApiResponse<Long> adminTagCreate(@Valid @RequestBody AdminTagCreateRequest request,
-                                            Authentication authentication) {
+            Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         return ApiResponse.success(adminTagService.adminTagCreate(request, userId));
     }
@@ -46,8 +62,8 @@ public class AdminTagController {
      */
     @PutMapping("/{id}")
     public ApiResponse<Void> adminTagUpdate(@PathVariable("id") Long id,
-                                            @Valid @RequestBody AdminTagUpdateRequest request,
-                                            Authentication authentication) {
+            @Valid @RequestBody AdminTagUpdateRequest request,
+            Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         adminTagService.adminTagUpdate(id, request, userId);
         return ApiResponse.success("更新成功");
@@ -68,8 +84,8 @@ public class AdminTagController {
      */
     @PutMapping("/{id}/approve")
     public ApiResponse<Void> adminTagApprove(@PathVariable("id") Long id,
-                                             @Valid @RequestBody AdminTagApprovalRequest request,
-                                             Authentication authentication) {
+            @Valid @RequestBody AdminTagApprovalRequest request,
+            Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         adminTagService.adminTagApprove(id, request, userId);
         return ApiResponse.success("审核成功");
@@ -81,6 +97,37 @@ public class AdminTagController {
     @GetMapping("/pending")
     public ApiResponse<List<AdminTagPendingResponse>> adminGetPendingTags() {
         return ApiResponse.success(adminTagService.adminGetPendingTags());
+    }
+
+    /**
+     * 获取未使用的标签列表
+     */
+    @GetMapping("/unused")
+    public ApiResponse<List<AdminTagUnusedResponse>> adminGetUnusedTags(
+            @RequestParam(value = "unusedDays", required = false) Integer unusedDays) {
+        return ApiResponse.success(adminTagService.adminGetUnusedTags(unusedDays));
+    }
+
+    /**
+     * 清理未使用的标签
+     */
+    @DeleteMapping("/cleanup")
+    public ApiResponse<AdminTagCleanupResponse> adminCleanupUnusedTags(
+            @RequestParam(value = "unusedDays", required = false, defaultValue = "30") Integer unusedDays,
+            Authentication authentication) {
+        Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
+        return ApiResponse.success(adminTagService.adminCleanupUnusedTags(unusedDays, userId));
+    }
+
+    /**
+     * 合并标签
+     */
+    @PostMapping("/merge")
+    public ApiResponse<Void> adminMergeTags(@Valid @RequestBody AdminTagMergeRequest request,
+            Authentication authentication) {
+        Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
+        adminTagService.adminMergeTags(request, userId);
+        return ApiResponse.success("标签合并成功");
     }
 
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
@@ -34,29 +34,29 @@ public class AdminTagController {
      * 获取管理员标签列表
      */
     @GetMapping("")
-    public ApiResponse<PageResponse<AdminTagListResponse>> getAdminTagList(@Valid AdminTagListParams params) {
-        return ApiResponse.success(adminTagService.getAdminTagList(params));
+    public ApiResponse<PageResponse<AdminTagListResponse>> adminGetTagList(@Valid AdminTagListParams params) {
+        return ApiResponse.success(adminTagService.adminGetTagList(params));
     }
 
     /**
      * 创建新标签
      */
     @PostMapping("")
-    public ApiResponse<Long> createAdminTag(@Valid @RequestBody AdminTagCreateRequest request,
+    public ApiResponse<Long> adminTagCreate(@Valid @RequestBody AdminTagCreateRequest request,
             Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
-        return ApiResponse.success(adminTagService.createAdminTag(request, userId));
+        return ApiResponse.success(adminTagService.adminTagCreate(request, userId));
     }
 
     /**
      * 更新标签
      */
     @PutMapping("/{id}")
-    public ApiResponse<Void> updateAdminTag(@PathVariable("id") Long id,
+    public ApiResponse<Void> adminTagUpdate(@PathVariable("id") Long id,
             @Valid @RequestBody AdminTagUpdateRequest request,
             Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
-        adminTagService.updateAdminTag(id, request, userId);
+        adminTagService.adminTagUpdate(id, request, userId);
         return ApiResponse.success();
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
@@ -1,13 +1,7 @@
 package com.kisesaki.blog.content.tag.controller;
 
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
@@ -57,6 +51,16 @@ public class AdminTagController {
             Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         adminTagService.adminTagUpdate(id, request, userId);
-        return ApiResponse.success();
+        return ApiResponse.success("更新成功");
+    }
+
+    /**
+     * 删除标签
+     */
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> adminTagDelete(@PathVariable("id") Long id, Authentication authentication) {
+        Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
+        adminTagService.adminTagDelete(id, userId);
+        return ApiResponse.success("删除成功");
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
@@ -1,0 +1,32 @@
+package com.kisesaki.blog.content.tag.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kisesaki.blog.common.dto.ApiResponse;
+import com.kisesaki.blog.common.dto.PageResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
+import com.kisesaki.blog.content.tag.service.AdminTagService;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/admin/tags")
+@RequiredArgsConstructor
+@Tag(name = "标签管理", description = "标签管理相关接口")
+public class AdminTagController {
+
+    private final AdminTagService adminTagService;
+
+    /**
+     * 获取管理员标签列表
+     */
+    @GetMapping("")
+    public ApiResponse<PageResponse<AdminTagListResponse>> getAdminTagList(@Valid AdminTagListParams params) {
+        return ApiResponse.success(adminTagService.getAdminTagList(params));
+    }
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
@@ -1,8 +1,9 @@
 package com.kisesaki.blog.content.tag.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.kisesaki.blog.common.util.AuthUtils;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCreateRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
@@ -28,5 +29,15 @@ public class AdminTagController {
     @GetMapping("")
     public ApiResponse<PageResponse<AdminTagListResponse>> getAdminTagList(@Valid AdminTagListParams params) {
         return ApiResponse.success(adminTagService.getAdminTagList(params));
+    }
+
+
+    /**
+     * 创建新标签
+     */
+    @PostMapping("")
+    public ApiResponse<Long> createAdminTag(@Valid @RequestBody AdminTagCreateRequest request, Authentication authentication) {
+        Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
+        return ApiResponse.success(adminTagService.createAdminTag(request, userId));
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/admin/tags")
 @RequiredArgsConstructor
@@ -61,6 +63,9 @@ public class AdminTagController {
         return ApiResponse.success("删除成功");
     }
 
+    /**
+     * 审核标签
+     */
     @PutMapping("/{id}/approve")
     public ApiResponse<Void> adminTagApprove(@PathVariable("id") Long id,
                                              @Valid @RequestBody AdminTagApprovalRequest request,
@@ -69,4 +74,13 @@ public class AdminTagController {
         adminTagService.adminTagApprove(id, request, userId);
         return ApiResponse.success("审核成功");
     }
+
+    /**
+     * 获取所有待审核标签
+     */
+    @GetMapping("/pending")
+    public ApiResponse<List<AdminTagPendingResponse>> adminGetPendingTags() {
+        return ApiResponse.success(adminTagService.adminGetPendingTags());
+    }
+
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
@@ -1,15 +1,12 @@
 package com.kisesaki.blog.content.tag.controller;
 
+import com.kisesaki.blog.content.tag.dto.AdminCommand.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.common.util.AuthUtils;
-import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCreateRequest;
-import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
-import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
-import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagUpdateRequest;
 import com.kisesaki.blog.content.tag.service.AdminTagService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,7 +34,7 @@ public class AdminTagController {
      */
     @PostMapping("")
     public ApiResponse<Long> adminTagCreate(@Valid @RequestBody AdminTagCreateRequest request,
-            Authentication authentication) {
+                                            Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         return ApiResponse.success(adminTagService.adminTagCreate(request, userId));
     }
@@ -47,8 +44,8 @@ public class AdminTagController {
      */
     @PutMapping("/{id}")
     public ApiResponse<Void> adminTagUpdate(@PathVariable("id") Long id,
-            @Valid @RequestBody AdminTagUpdateRequest request,
-            Authentication authentication) {
+                                            @Valid @RequestBody AdminTagUpdateRequest request,
+                                            Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         adminTagService.adminTagUpdate(id, request, userId);
         return ApiResponse.success("更新成功");
@@ -62,5 +59,14 @@ public class AdminTagController {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         adminTagService.adminTagDelete(id, userId);
         return ApiResponse.success("删除成功");
+    }
+
+    @PutMapping("/{id}/approve")
+    public ApiResponse<Void> adminTagApprove(@PathVariable("id") Long id,
+                                             @Valid @RequestBody AdminTagApprovalRequest request,
+                                             Authentication authentication) {
+        Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
+        adminTagService.adminTagApprove(id, request, userId);
+        return ApiResponse.success("审核成功");
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/TagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/TagController.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.content.tag;
+package com.kisesaki.blog.content.tag.controller;
 
 import java.util.List;
 

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagApprovalRequest.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagApprovalRequest.java
@@ -1,0 +1,24 @@
+package com.kisesaki.blog.content.tag.dto.AdminCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "标签审核请求")
+public class AdminTagApprovalRequest {
+    @NotNull(message = "审核状态不能为空")
+    @Pattern(regexp = "^(approved|rejected)$", message = "审核状态只能是 approved 或 rejected")
+    @Schema(description = "审核状态", example = "approved", allowableValues = { "approved", "rejected" }, required = true)
+    private String status;
+
+    @Size(max = 200, message = "审核备注长度不能超过200字符")
+    @Schema(description = "审核备注", example = "标签符合规范，审核通过")
+    private String note;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagCleanupResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagCleanupResponse.java
@@ -1,0 +1,21 @@
+package com.kisesaki.blog.content.tag.dto.AdminCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "标签清理结果响应")
+public class AdminTagCleanupResponse {
+    @Schema(description = "清理的标签数量", example = "5")
+    private Integer cleanedCount;
+
+    @Schema(description = "清理前未使用标签总数", example = "10")
+    private Integer totalUnusedCount;
+
+    @Schema(description = "清理操作描述", example = "已清理5个超过30天未使用的标签")
+    private String message;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagCreateRequest.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagCreateRequest.java
@@ -1,0 +1,40 @@
+package com.kisesaki.blog.content.tag.dto.AdminCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "管理员创建标签请求")
+public class AdminTagCreateRequest {
+    @NotBlank(message = "标签名称不能为空")
+    @Size(min = 1, max = 50, message = "标签名称长度必须在1-50字符之间")
+    @Schema(description = "标签名称", example = "Spring Boot")
+    private String name;
+
+    @Size(max = 50, message = "URL别名长度不能超过50字符")
+    @Pattern(regexp = "^[a-z0-9\\-]*$", message = "URL别名只能包含小写字母、数字和短横线")
+    @Schema(description = "URL友好别名，不传递就后端自动生成", example = "spring-boot")
+    private String slug;
+
+    @Size(max = 500, message = "标签描述长度不能超过500字符")
+    @Schema(description = "标签描述", example = "关于Spring Boot框架的文章")
+    private String description;
+
+    @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "颜色必须是有效的HEX格式")
+    @Schema(description = "标签颜色（HEX格式），不传递就后端随机生成", example = "#3498db")
+    private String color;
+
+    @Schema(description = "是否立即审核通过", example = "true")
+    private Boolean isApproved = true;
+
+    @Size(max = 200, message = "审核备注长度不能超过200字符")
+    @Schema(description = "审核备注", example = "管理员直接创建，自动审核通过")
+    private String approvalNote;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagListParams.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagListParams.java
@@ -1,0 +1,37 @@
+package com.kisesaki.blog.content.tag.dto.AdminCommand;
+
+import com.kisesaki.blog.common.dto.PageableParams;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "管理员标签列表请求参数")
+public class AdminTagListParams {
+    @Valid
+    @Schema(description = "分页参数")
+    private PageableParams pageable = new PageableParams();
+
+    @Schema(description = "标签名称，支持模糊搜索", example = "Git")
+    private String name;
+
+    @Schema(description = "审核状态过滤", example = "pending", allowableValues = { "pending", "approved", "rejected" })
+    private String approvalStatus;
+
+    @Schema(description = "创建者ID过滤", example = "1")
+    private Long createdBy;
+
+    @Schema(description = "是否只显示未使用的标签", example = "false")
+    private Boolean unusedOnly = false;
+
+    @Schema(description = "最小使用次数过滤", example = "0")
+    private Integer minPostCount = 0;
+
+    @Schema(description = "最大使用次数过滤", example = "100")
+    private Integer maxPostCount;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagListResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagListResponse.java
@@ -1,0 +1,68 @@
+package com.kisesaki.blog.content.tag.dto.AdminCommand;
+
+import java.time.OffsetDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "管理员标签列表响应数据")
+public class AdminTagListResponse {
+    @Schema(description = "标签ID", example = "1")
+    private Long id;
+
+    @Schema(description = "标签名称", example = "Java")
+    private String name;
+
+    @Schema(description = "标签别名（URL 友好）", example = "java")
+    private String slug;
+
+    @Schema(description = "标签描述", example = "关于 Java 编程语言的文章")
+    private String description;
+
+    @Schema(description = "颜色（HEX）", example = "#f1e05a")
+    private String color;
+
+    @Schema(description = "使用该标签的文章数量", example = "42")
+    private Integer postCount;
+
+    @Schema(description = "创建时间", example = "2023-10-01T12:34:56Z")
+    private OffsetDateTime createdAt;
+
+    @Schema(description = "更新时间", example = "2023-10-15T14:30:22Z")
+    private OffsetDateTime updatedAt;
+
+    @Schema(description = "创建者ID", example = "1")
+    private Long createdBy;
+
+    @Schema(description = "创建者用户名", example = "user1")
+    private String createdByUsername;
+
+    @Schema(description = "是否已审核通过", example = "true")
+    private Boolean isApproved;
+
+    @Schema(description = "审核状态", example = "approved", allowableValues = { "pending", "approved", "rejected" })
+    private String approvalStatus;
+
+    @Schema(description = "审核者ID", example = "2")
+    private Long approvedBy;
+
+    @Schema(description = "审核者用户名", example = "admin")
+    private String approvedByUsername;
+
+    @Schema(description = "审核时间", example = "2023-10-02T10:15:30Z")
+    private OffsetDateTime approvedAt;
+
+    @Schema(description = "审核备注", example = "标签符合规范，审核通过")
+    private String approvalNote;
+
+    @Schema(description = "最近使用时间", example = "2023-10-15T18:45:12Z")
+    private OffsetDateTime lastUsedAt;
+
+    @Schema(description = "热度权重", example = "85.5")
+    private Double popularityScore;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagMergeRequest.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagMergeRequest.java
@@ -1,0 +1,21 @@
+package com.kisesaki.blog.content.tag.dto.AdminCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "标签合并请求")
+public class AdminTagMergeRequest {
+    @NotNull(message = "源标签ID不能为空")
+    @Schema(description = "源标签ID（将被合并的标签）", example = "5", required = true)
+    private Long sourceTagId;
+
+    @NotNull(message = "目标标签ID不能为空")
+    @Schema(description = "目标标签ID（合并到的标签）", example = "3", required = true)
+    private Long targetTagId;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagPendingResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagPendingResponse.java
@@ -1,0 +1,38 @@
+package com.kisesaki.blog.content.tag.dto.AdminCommand;
+
+import java.time.OffsetDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "待审核标签响应数据")
+public class AdminTagPendingResponse {
+    @Schema(description = "标签ID", example = "1")
+    private Long id;
+
+    @Schema(description = "标签名称", example = "Java")
+    private String name;
+
+    @Schema(description = "标签别名（URL 友好）", example = "java")
+    private String slug;
+
+    @Schema(description = "标签描述", example = "关于 Java 编程语言的文章")
+    private String description;
+
+    @Schema(description = "颜色（HEX）", example = "#f1e05a")
+    private String color;
+
+    @Schema(description = "创建时间", example = "2023-10-01T12:34:56Z")
+    private OffsetDateTime createdAt;
+
+    @Schema(description = "创建者ID", example = "1")
+    private Long createdBy;
+
+    @Schema(description = "创建者用户名", example = "user1")
+    private String createdByUsername;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagUnusedResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagUnusedResponse.java
@@ -1,0 +1,44 @@
+package com.kisesaki.blog.content.tag.dto.AdminCommand;
+
+import java.time.OffsetDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "未使用标签响应数据")
+public class AdminTagUnusedResponse {
+    @Schema(description = "标签ID", example = "1")
+    private Long id;
+
+    @Schema(description = "标签名称", example = "Java")
+    private String name;
+
+    @Schema(description = "标签别名（URL 友好）", example = "java")
+    private String slug;
+
+    @Schema(description = "标签描述", example = "关于 Java 编程语言的文章")
+    private String description;
+
+    @Schema(description = "颜色（HEX）", example = "#f1e05a")
+    private String color;
+
+    @Schema(description = "创建时间", example = "2023-10-01T12:34:56Z")
+    private OffsetDateTime createdAt;
+
+    @Schema(description = "创建者ID", example = "1")
+    private Long createdBy;
+
+    @Schema(description = "创建者用户名", example = "user1")
+    private String createdByUsername;
+
+    @Schema(description = "未使用天数", example = "30")
+    private Integer unusedDays;
+
+    @Schema(description = "是否已审核通过", example = "true")
+    private Boolean isApproved;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagUpdateRequest.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/AdminCommand/AdminTagUpdateRequest.java
@@ -1,0 +1,38 @@
+package com.kisesaki.blog.content.tag.dto.AdminCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "管理员更新标签请求")
+public class AdminTagUpdateRequest {
+    @Size(min = 1, max = 50, message = "标签名称长度必须在1-50字符之间")
+    @Schema(description = "标签名称", example = "Spring Boot")
+    private String name;
+
+    @Size(max = 50, message = "URL别名长度不能超过50字符")
+    @Pattern(regexp = "^[a-z0-9\\-]*$", message = "URL别名只能包含小写字母、数字和短横线")
+    @Schema(description = "URL友好别名", example = "spring-boot")
+    private String slug;
+
+    @Size(max = 500, message = "标签描述长度不能超过500字符")
+    @Schema(description = "标签描述", example = "关于Spring Boot框架的文章")
+    private String description;
+
+    @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "颜色必须是有效的HEX格式")
+    @Schema(description = "标签颜色（HEX格式）", example = "#3498db")
+    private String color;
+
+    @Schema(description = "是否审核通过", example = "true")
+    private Boolean isApproved;
+
+    @Size(max = 200, message = "审核备注长度不能超过200字符")
+    @Schema(description = "审核备注", example = "标签信息已更新，审核通过")
+    private String approvalNote;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagCreateRequest.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagCreateRequest.java
@@ -1,0 +1,33 @@
+package com.kisesaki.blog.content.tag.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "用户创建标签请求")
+public class TagCreateRequest {
+    @NotBlank(message = "标签名称不能为空")
+    @Size(min = 1, max = 50, message = "标签名称长度必须在1-50字符之间")
+    @Schema(description = "标签名称", example = "Spring Boot", required = true)
+    private String name;
+
+    @Size(max = 500, message = "标签描述长度不能超过500字符")
+    @Schema(description = "标签描述", example = "关于Spring Boot框架的文章")
+    private String description;
+
+    @Size(max = 50, message = "URL别名长度不能超过50字符")
+    @Pattern(regexp = "^[a-z0-9\\-]*$", message = "URL别名只能包含小写字母、数字和短横线")
+    @Schema(description = "URL友好别名，不传递就后端自动生成", example = "spring-boot")
+    private String slug;
+
+    @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "颜色必须是有效的HEX格式")
+    @Schema(description = "标签颜色（HEX格式），不传递就后端随机生成", example = "#3498db")
+    private String color;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagListParams.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagListParams.java
@@ -1,0 +1,22 @@
+package com.kisesaki.blog.content.tag.dto;
+
+import com.kisesaki.blog.common.dto.PageableParams;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "标签列表请求参数")
+public class TagListParams {
+    @Valid
+    @Schema(description = "分页参数")
+    private PageableParams pageable = new PageableParams();
+
+    @Schema(description = "标签名称，支持模糊搜索", example = "Git")
+    private String name;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagListResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagListResponse.java
@@ -1,0 +1,35 @@
+package com.kisesaki.blog.content.tag.dto;
+
+import java.time.OffsetDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "标签列表响应数据")
+public class TagListResponse {
+    @Schema(description = "标签ID", example = "1")
+    private Long id;
+
+    @Schema(description = "标签名称", example = "Java")
+    private String name;
+
+    @Schema(description = "标签别名（URL 友好）", example = "java")
+    private String slug;
+
+    @Schema(description = "标签描述", example = "关于 Java 编程语言的文章")
+    private String description;
+
+    @Schema(description = "颜色（HEX）", example = "#f1e05a")
+    private String color;
+
+    @Schema(description = "使用该标签的文章数量", example = "42")
+    private Integer postCount;
+
+    @Schema(description = "创建时间", example = "2023-10-01T12:34:56Z")
+    private OffsetDateTime createdAt;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/MyTagResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/MyTagResponse.java
@@ -1,0 +1,44 @@
+package com.kisesaki.blog.content.tag.dto.TagQuery;
+
+import java.time.OffsetDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "我创建的标签响应数据")
+public class MyTagResponse {
+    @Schema(description = "标签ID", example = "1")
+    private Long id;
+
+    @Schema(description = "标签名称", example = "Java")
+    private String name;
+
+    @Schema(description = "标签别名（URL 友好）", example = "java")
+    private String slug;
+
+    @Schema(description = "标签描述", example = "关于 Java 编程语言的文章")
+    private String description;
+
+    @Schema(description = "颜色（HEX）", example = "#f1e05a")
+    private String color;
+
+    @Schema(description = "使用该标签的文章数量", example = "42")
+    private Integer postCount;
+
+    @Schema(description = "创建时间", example = "2023-10-01T12:34:56Z")
+    private OffsetDateTime createdAt;
+
+    @Schema(description = "是否已审核通过", example = "true")
+    private Boolean isApproved;
+
+    @Schema(description = "审核状态", example = "approved", allowableValues = { "pending", "approved", "rejected" })
+    private String approvalStatus;
+
+    @Schema(description = "审核备注", example = "标签名称重复，建议使用其他名称")
+    private String approvalNote;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/PopularTagResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/PopularTagResponse.java
@@ -1,0 +1,35 @@
+package com.kisesaki.blog.content.tag.dto.TagQuery;
+
+import java.time.OffsetDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "热门标签响应数据")
+public class PopularTagResponse {
+    @Schema(description = "标签ID", example = "1")
+    private Long id;
+
+    @Schema(description = "标签名称", example = "Java")
+    private String name;
+
+    @Schema(description = "标签别名（URL 友好）", example = "java")
+    private String slug;
+
+    @Schema(description = "颜色（HEX）", example = "#f1e05a")
+    private String color;
+
+    @Schema(description = "使用该标签的文章数量", example = "42")
+    private Integer postCount;
+
+    @Schema(description = "热度权重（基于文章数量、阅读量等计算）", example = "85.5")
+    private Double popularityScore;
+
+    @Schema(description = "最近使用时间", example = "2023-10-15T14:30:22Z")
+    private OffsetDateTime lastUsedAt;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagCloudItem.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagCloudItem.java
@@ -1,0 +1,33 @@
+package com.kisesaki.blog.content.tag.dto.TagQuery;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "标签云项数据")
+public class TagCloudItem {
+    @Schema(description = "标签ID", example = "1")
+    private Long id;
+
+    @Schema(description = "标签名称", example = "Java")
+    private String name;
+
+    @Schema(description = "标签别名（URL 友好）", example = "java")
+    private String slug;
+
+    @Schema(description = "颜色（HEX）", example = "#f1e05a")
+    private String color;
+
+    @Schema(description = "使用该标签的文章数量", example = "42")
+    private Integer postCount;
+
+    @Schema(description = "字体大小权重（1-10）", example = "8")
+    private Integer fontWeight;
+
+    @Schema(description = "热度权重（基于文章数量、阅读量等计算）", example = "85.5")
+    private Double popularityScore;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagDetailResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagDetailResponse.java
@@ -1,0 +1,47 @@
+package com.kisesaki.blog.content.tag.dto.TagQuery;
+
+import java.time.OffsetDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "标签详情响应数据")
+public class TagDetailResponse {
+    @Schema(description = "标签ID", example = "1")
+    private Long id;
+
+    @Schema(description = "标签名称", example = "Java")
+    private String name;
+
+    @Schema(description = "标签别名（URL 友好）", example = "java")
+    private String slug;
+
+    @Schema(description = "标签描述", example = "关于 Java 编程语言的文章")
+    private String description;
+
+    @Schema(description = "颜色（HEX）", example = "#f1e05a")
+    private String color;
+
+    @Schema(description = "使用该标签的文章数量", example = "42")
+    private Integer postCount;
+
+    @Schema(description = "创建时间", example = "2023-10-01T12:34:56Z")
+    private OffsetDateTime createdAt;
+
+    @Schema(description = "更新时间", example = "2023-10-15T14:30:22Z")
+    private OffsetDateTime updatedAt;
+
+    @Schema(description = "创建者ID", example = "1")
+    private Long createdBy;
+
+    @Schema(description = "创建者用户名", example = "admin")
+    private String createdByUsername;
+
+    @Schema(description = "是否已审核通过", example = "true")
+    private Boolean isApproved;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagListParams.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagListParams.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.content.tag.dto;
+package com.kisesaki.blog.content.tag.dto.TagQuery;
 
 import com.kisesaki.blog.common.dto.PageableParams;
 

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagListResponse.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagListResponse.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.content.tag.dto;
+package com.kisesaki.blog.content.tag.dto.TagQuery;
 
 import java.time.OffsetDateTime;
 

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagPostsParams.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagPostsParams.java
@@ -1,0 +1,28 @@
+package com.kisesaki.blog.content.tag.dto.TagQuery;
+
+import com.kisesaki.blog.common.dto.PageableParams;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "标签下文章列表请求参数")
+public class TagPostsParams {
+    @Valid
+    @Schema(description = "分页参数")
+    private PageableParams pageable = new PageableParams();
+
+    @Schema(description = "文章状态过滤", example = "published", allowableValues = { "draft", "published", "archived" })
+    private String status = "published";
+
+    @Schema(description = "可见性过滤", example = "public", allowableValues = { "public", "private", "password_protected" })
+    private String visibility = "public";
+
+    @Schema(description = "是否只显示精选文章", example = "false")
+    private Boolean featuredOnly = false;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagSearchItem.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagSearchItem.java
@@ -1,0 +1,33 @@
+package com.kisesaki.blog.content.tag.dto.TagQuery;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "标签搜索结果项")
+public class TagSearchItem {
+    @Schema(description = "标签ID", example = "1")
+    private Long id;
+
+    @Schema(description = "标签名称", example = "Java")
+    private String name;
+
+    @Schema(description = "标签别名（URL 友好）", example = "java")
+    private String slug;
+
+    @Schema(description = "标签描述", example = "关于 Java 编程语言的文章")
+    private String description;
+
+    @Schema(description = "颜色（HEX）", example = "#f1e05a")
+    private String color;
+
+    @Schema(description = "使用该标签的文章数量", example = "42")
+    private Integer postCount;
+
+    @Schema(description = "匹配得分（用于排序）", example = "0.95")
+    private Double matchScore;
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagSearchParams.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/dto/TagQuery/TagSearchParams.java
@@ -1,0 +1,30 @@
+package com.kisesaki.blog.content.tag.dto.TagQuery;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "标签搜索请求参数")
+public class TagSearchParams {
+    @Schema(description = "搜索关键词", example = "Java")
+    @Size(min = 1, max = 50, message = "搜索关键词长度必须在1-50字符之间")
+    private String q;
+
+    @Schema(description = "返回结果数量限制", example = "10", minimum = "1", maximum = "50")
+    @Min(value = 1, message = "返回数量最小为1")
+    @Max(value = 50, message = "返回数量最大为50")
+    private Integer limit = 10;
+
+    @Schema(description = "是否只搜索已审核通过的标签", example = "true")
+    private Boolean approvedOnly = true;
+
+    @Schema(description = "排序方式", example = "popularity", allowableValues = { "name", "popularity", "created_at" })
+    private String sort = "popularity";
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/entity/Tags.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/entity/Tags.java
@@ -36,4 +36,31 @@ public class Tags {
     /* 创建时间 */
     private OffsetDateTime createdAt;
 
+    /* 更新时间 */
+    private OffsetDateTime updatedAt;
+
+    /* 创建者ID */
+    private Long createdBy;
+
+    /* 是否已审核通过 */
+    private Boolean isApproved;
+
+    /* 审核状态：pending, approved, rejected */
+    private String approvalStatus;
+
+    /* 审核者ID */
+    private Long approvedBy;
+
+    /* 审核时间 */
+    private OffsetDateTime approvedAt;
+
+    /* 审核备注 */
+    private String approvalNote;
+
+    /* 最近使用时间 */
+    private OffsetDateTime lastUsedAt;
+
+    /* 热度权重（基于文章数量、阅读量等计算） */
+    private Double popularityScore;
+
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
@@ -1,6 +1,7 @@
 package com.kisesaki.blog.content.tag.mapper;
 
-import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagPendingResponse;
+import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.data.repository.query.Param;
 
@@ -8,10 +9,10 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
 import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagPendingResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagUnusedResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.entity.Tags;
-
-import java.util.List;
 
 @Mapper
 public interface TagsMapper extends BaseMapper<Tags> {
@@ -43,4 +44,29 @@ public interface TagsMapper extends BaseMapper<Tags> {
      * 获取所有待审核标签
      */
     List<AdminTagPendingResponse> getPendingTags();
+
+    /**
+     * 获取未使用的标签列表
+     */
+    List<AdminTagUnusedResponse> getUnusedTags(@Param("unusedDays") Integer unusedDays);
+
+    /**
+     * 删除未使用的标签
+     */
+    int deleteUnusedTags(@Param("unusedDays") Integer unusedDays);
+
+    /**
+     * 将源标签的所有文章转移到目标标签
+     */
+    int transferPostsFromSourceToTarget(@Param("sourceTagId") Long sourceTagId, @Param("targetTagId") Long targetTagId);
+
+    /**
+     * 删除指定标签的所有文章关联
+     */
+    int deletePostTagsByTagId(@Param("tagId") Long tagId);
+
+    /**
+     * 更新目标标签的文章计数
+     */
+    void updateTagPostCount(@Param("tagId") Long tagId);
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
@@ -1,9 +1,12 @@
 package com.kisesaki.blog.content.tag.mapper;
 
-import com.baomidou.mybatisplus.core.mapper.BaseMapper;
-import com.kisesaki.blog.content.tag.entity.Tags;
 import org.apache.ibatis.annotations.Mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
+import com.kisesaki.blog.content.tag.entity.Tags;
 
 @Mapper
 public interface TagsMapper extends BaseMapper<Tags> {
+    TagDetailResponse getTagDetailById(Long id);
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
@@ -1,5 +1,6 @@
 package com.kisesaki.blog.content.tag.mapper;
 
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagPendingResponse;
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.data.repository.query.Param;
 
@@ -9,6 +10,8 @@ import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
 import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.entity.Tags;
+
+import java.util.List;
 
 @Mapper
 public interface TagsMapper extends BaseMapper<Tags> {
@@ -35,4 +38,9 @@ public interface TagsMapper extends BaseMapper<Tags> {
     Page<AdminTagListResponse> getAdminTagList(
             @Param("page") Page<AdminTagListResponse> page,
             @Param("params") AdminTagListParams params);
+
+    /**
+     * 获取所有待审核标签
+     */
+    List<AdminTagPendingResponse> getPendingTags();
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
@@ -8,5 +8,20 @@ import com.kisesaki.blog.content.tag.entity.Tags;
 
 @Mapper
 public interface TagsMapper extends BaseMapper<Tags> {
+
+    /**
+     * 根据ID查询标签详情
+     * 
+     * @param slug 标签Slug
+     * @return 标签详情
+     */
     TagDetailResponse getTagDetailById(Long id);
+
+    /**
+     * 根据Slug查询标签详情
+     * 
+     * @param slug 标签Slug
+     * @return 标签详情
+     */
+    TagDetailResponse getTagDetailBySlug(String slug);
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/mapper/TagsMapper.java
@@ -1,8 +1,12 @@
 package com.kisesaki.blog.content.tag.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.springframework.data.repository.query.Param;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.entity.Tags;
 
@@ -24,4 +28,11 @@ public interface TagsMapper extends BaseMapper<Tags> {
      * @return 标签详情
      */
     TagDetailResponse getTagDetailBySlug(String slug);
+
+    /**
+     * 获取管理员标签列表
+     */
+    Page<AdminTagListResponse> getAdminTagList(
+            @Param("page") Page<AdminTagListResponse> page,
+            @Param("params") AdminTagListParams params);
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
@@ -1,5 +1,11 @@
 package com.kisesaki.blog.content.tag.service;
 
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.kisesaki.blog.common.enums.ErrorCode;
+import com.kisesaki.blog.common.exception.BusinessException;
+import com.kisesaki.blog.common.util.SlugUtils;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCreateRequest;
+import com.kisesaki.blog.content.tag.entity.Tags;
 import org.springframework.stereotype.Service;
 
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
@@ -11,6 +17,9 @@ import com.kisesaki.blog.content.tag.mapper.TagsMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.OffsetDateTime;
+import java.util.Random;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -20,7 +29,7 @@ public class AdminTagService {
 
     /**
      * 获取管理员标签列表
-     * 
+     *
      * @param params 分页参数
      * @return 分页响应结果
      */
@@ -44,5 +53,97 @@ public class AdminTagService {
                 result.getRecords(),
                 totalCount != null ? totalCount : 0L,
                 params.getPageable());
+    }
+
+    /**
+     * 创建新标签
+     *
+     * @param request 创建请求参数
+     * @return 新创建标签的ID
+     */
+    public Long createAdminTag(AdminTagCreateRequest request, Long userId) {
+        // 检查标签名称是否已存在
+        LambdaQueryWrapper<Tags> nameWrapper = new LambdaQueryWrapper<Tags>()
+                .eq(Tags::getName, request.getName());
+        if (tagsMapper.selectCount(nameWrapper) > 0) {
+            throw BusinessException.of(ErrorCode.PARAM_ERROR, "标签名称已存在");
+        }
+
+        // 生成slug并检查是否已存在
+        String slug = request.getSlug();
+        if (slug == null || slug.trim().isEmpty()) {
+            slug = SlugUtils.generateSlug(request.getName());
+        }
+        LambdaQueryWrapper<Tags> slugWrapper = new LambdaQueryWrapper<Tags>()
+                .eq(Tags::getSlug, slug);
+        if (tagsMapper.selectCount(slugWrapper) > 0) {
+            // 自动添加后缀避免冲突
+            slug = generateUniqueSlug(slug);
+        }
+
+        // 生成颜色
+        String color = request.getColor();
+        if (color == null || color.trim().isEmpty()) {
+            color = generateRandomColor();
+        }
+
+        // 创建标签实体
+        Tags tag = new Tags();
+        tag.setName(request.getName());
+        tag.setSlug(slug);
+        tag.setDescription(request.getDescription());
+        tag.setColor(color);
+        tag.setPostCount(0);
+        tag.setPopularityScore(0.0);
+        tag.setCreatedBy(userId);
+        tag.setCreatedAt(OffsetDateTime.now());
+        tag.setUpdatedAt(OffsetDateTime.now());
+
+        if (request.getIsApproved() != null && request.getIsApproved()) {
+            tag.setIsApproved(true);
+            tag.setApprovalStatus("approved");
+            tag.setApprovedBy(userId);
+            tag.setApprovedAt(OffsetDateTime.now());
+            tag.setApprovalNote(request.getApprovalNote());
+        } else {
+            tag.setIsApproved(false); // 需要审核
+            tag.setApprovalStatus("pending");
+        }
+
+        // 保存标签
+        tagsMapper.insert(tag);
+
+        log.info("管理员用户 {} 创建了标签: {}", userId, tag.getName());
+
+        return tag.getId();
+    }
+
+    /**
+     * 生成唯一的slug
+     */
+    private String generateUniqueSlug(String baseSlug) {
+        int counter = 1;
+        String candidateSlug = baseSlug + "-" + counter;
+
+        while (tagsMapper.selectCount(new LambdaQueryWrapper<Tags>().eq(Tags::getSlug, candidateSlug)) > 0) {
+            counter++;
+            candidateSlug = baseSlug + "-" + counter;
+        }
+
+        return candidateSlug;
+    }
+
+    /**
+     * 生成随机颜色
+     */
+    private String generateRandomColor() {
+        String[] colors = {
+                "#3498db", "#e74c3c", "#2ecc71", "#f39c12", "#9b59b6",
+                "#1abc9c", "#34495e", "#e67e22", "#95a5a6", "#16a085",
+                "#27ae60", "#2980b9", "#8e44ad", "#f1c40f", "#e74c3c",
+                "#ecf0f1", "#bdc3c7", "#d35400", "#c0392b", "#7f8c8d"
+        };
+        Random random = new Random();
+        return colors[random.nextInt(colors.length)];
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
@@ -1,0 +1,48 @@
+package com.kisesaki.blog.content.tag.service;
+
+import org.springframework.stereotype.Service;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.kisesaki.blog.common.dto.PageResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
+import com.kisesaki.blog.content.tag.mapper.TagsMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminTagService {
+
+    private final TagsMapper tagsMapper;
+
+    /**
+     * 获取管理员标签列表
+     * 
+     * @param params 分页参数
+     * @return 分页响应结果
+     */
+    public PageResponse<AdminTagListResponse> getAdminTagList(AdminTagListParams params) {
+        // 构建分页对象
+        Page<AdminTagListResponse> page = new Page<>(
+                params.getPageable().getCurrentPage(),
+                params.getPageable().getPageSize());
+
+        // 根据 includeTotal 参数决定是否需要计算总数
+        if (!params.getPageable().getIncludeTotal()) {
+            page.setSearchCount(false);
+        }
+
+        // 执行分页查询
+        Page<AdminTagListResponse> result = tagsMapper.getAdminTagList(page, params);
+
+        Long totalCount = params.getPageable().getIncludeTotal() ? result.getTotal() : null;
+
+        return PageResponse.of(
+                result.getRecords(),
+                totalCount != null ? totalCount : 0L,
+                params.getPageable());
+    }
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
@@ -148,4 +148,20 @@ public class AdminTagService {
         log.info("管理员用户 {} 更新了标签: {}", userId, tag.getName());
     }
 
+    /**
+     * 删除标签
+     *
+     * @param id     标签ID
+     * @param userId 操作用户ID
+     */
+    public void adminTagDelete(Long id, Long userId) {
+        Tags tag = tagsMapper.selectById(id);
+        if (tag == null) {
+            throw new IllegalArgumentException("标签不存在");
+        }
+
+        tagsMapper.deleteById(id);
+
+        log.info("管理员用户 {} 删除了标签: {}", userId, tag.getName());
+    }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
@@ -1,8 +1,8 @@
 package com.kisesaki.blog.content.tag.service;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 
-import com.kisesaki.blog.common.enums.ErrorCode;
 import com.kisesaki.blog.common.exception.BusinessException;
 import com.kisesaki.blog.content.tag.dto.AdminCommand.*;
 import org.springframework.stereotype.Service;
@@ -195,5 +195,14 @@ public class AdminTagService {
         tagsMapper.updateById(tag);
 
         log.info("管理员用户 {} 审核了标签: {}，状态: {}", userId, tag.getName(), request.getStatus());
+    }
+
+    /**
+     * 获取待审核标签数量
+     *
+     * @return 待审核标签
+     */
+    public List<AdminTagPendingResponse> adminGetPendingTags() {
+        return tagsMapper.getPendingTags();
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
@@ -2,14 +2,13 @@ package com.kisesaki.blog.content.tag.service;
 
 import java.time.OffsetDateTime;
 
+import com.kisesaki.blog.common.enums.ErrorCode;
+import com.kisesaki.blog.common.exception.BusinessException;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.*;
 import org.springframework.stereotype.Service;
 
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.kisesaki.blog.common.dto.PageResponse;
-import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCreateRequest;
-import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
-import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
-import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagUpdateRequest;
 import com.kisesaki.blog.content.tag.entity.Tags;
 import com.kisesaki.blog.content.tag.mapper.TagsMapper;
 import com.kisesaki.blog.content.tag.util.TagUtils;
@@ -163,5 +162,38 @@ public class AdminTagService {
         tagsMapper.deleteById(id);
 
         log.info("管理员用户 {} 删除了标签: {}", userId, tag.getName());
+    }
+
+    /**
+     * 审核标签
+     *
+     * @param id      标签ID
+     * @param request 审核请求参数
+     * @param userId  操作用户ID
+     */
+    public void adminTagApprove(Long id, AdminTagApprovalRequest request, Long userId) {
+        Tags tag = tagsMapper.selectById(id);
+        if (tag == null) {
+            throw BusinessException.notFound("被删除标签没找到");
+        }
+        if ("approved".equals(request.getStatus())) {
+            tag.setIsApproved(true);
+            tag.setApprovalStatus("approved");
+            tag.setApprovedBy(userId);
+            tag.setApprovedAt(OffsetDateTime.now());
+            tag.setApprovalNote(request.getNote());
+        } else if ("rejected".equals(request.getStatus())) {
+            tag.setIsApproved(false);
+            tag.setApprovalStatus("rejected");
+            tag.setApprovedBy(userId);
+            tag.setApprovedAt(OffsetDateTime.now());
+            tag.setApprovalNote(request.getNote());
+        } else {
+            throw BusinessException.paramError("无效的审核状态");
+        }
+
+        tagsMapper.updateById(tag);
+
+        log.info("管理员用户 {} 审核了标签: {}，状态: {}", userId, tag.getName(), request.getStatus());
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
@@ -1,24 +1,20 @@
 package com.kisesaki.blog.content.tag.service;
 
-import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
-import com.kisesaki.blog.common.enums.ErrorCode;
-import com.kisesaki.blog.common.exception.BusinessException;
-import com.kisesaki.blog.common.util.SlugUtils;
-import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCreateRequest;
-import com.kisesaki.blog.content.tag.entity.Tags;
+import java.time.OffsetDateTime;
+
 import org.springframework.stereotype.Service;
 
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.kisesaki.blog.common.dto.PageResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCreateRequest;
 import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
 import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
+import com.kisesaki.blog.content.tag.entity.Tags;
 import com.kisesaki.blog.content.tag.mapper.TagsMapper;
+import com.kisesaki.blog.content.tag.util.TagUtils;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.time.OffsetDateTime;
-import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +22,7 @@ import java.util.Random;
 public class AdminTagService {
 
     private final TagsMapper tagsMapper;
+    private final TagUtils tagUtils;
 
     /**
      * 获取管理员标签列表
@@ -62,37 +59,18 @@ public class AdminTagService {
      * @return 新创建标签的ID
      */
     public Long createAdminTag(AdminTagCreateRequest request, Long userId) {
-        // 检查标签名称是否已存在
-        LambdaQueryWrapper<Tags> nameWrapper = new LambdaQueryWrapper<Tags>()
-                .eq(Tags::getName, request.getName());
-        if (tagsMapper.selectCount(nameWrapper) > 0) {
-            throw BusinessException.of(ErrorCode.PARAM_ERROR, "标签名称已存在");
-        }
-
-        // 生成slug并检查是否已存在
-        String slug = request.getSlug();
-        if (slug == null || slug.trim().isEmpty()) {
-            slug = SlugUtils.generateSlug(request.getName());
-        }
-        LambdaQueryWrapper<Tags> slugWrapper = new LambdaQueryWrapper<Tags>()
-                .eq(Tags::getSlug, slug);
-        if (tagsMapper.selectCount(slugWrapper) > 0) {
-            // 自动添加后缀避免冲突
-            slug = generateUniqueSlug(slug);
-        }
-
-        // 生成颜色
-        String color = request.getColor();
-        if (color == null || color.trim().isEmpty()) {
-            color = generateRandomColor();
-        }
+        // 使用工具类验证和准备标签信息
+        TagUtils.TagValidationResult validationResult = tagUtils.validateAndPrepareTagInfo(
+                request.getName(),
+                request.getSlug(),
+                request.getColor());
 
         // 创建标签实体
         Tags tag = new Tags();
-        tag.setName(request.getName());
-        tag.setSlug(slug);
+        tag.setName(validationResult.getName());
+        tag.setSlug(validationResult.getSlug());
         tag.setDescription(request.getDescription());
-        tag.setColor(color);
+        tag.setColor(validationResult.getColor());
         tag.setPostCount(0);
         tag.setPopularityScore(0.0);
         tag.setCreatedBy(userId);
@@ -116,34 +94,5 @@ public class AdminTagService {
         log.info("管理员用户 {} 创建了标签: {}", userId, tag.getName());
 
         return tag.getId();
-    }
-
-    /**
-     * 生成唯一的slug
-     */
-    private String generateUniqueSlug(String baseSlug) {
-        int counter = 1;
-        String candidateSlug = baseSlug + "-" + counter;
-
-        while (tagsMapper.selectCount(new LambdaQueryWrapper<Tags>().eq(Tags::getSlug, candidateSlug)) > 0) {
-            counter++;
-            candidateSlug = baseSlug + "-" + counter;
-        }
-
-        return candidateSlug;
-    }
-
-    /**
-     * 生成随机颜色
-     */
-    private String generateRandomColor() {
-        String[] colors = {
-                "#3498db", "#e74c3c", "#2ecc71", "#f39c12", "#9b59b6",
-                "#1abc9c", "#34495e", "#e67e22", "#95a5a6", "#16a085",
-                "#27ae60", "#2980b9", "#8e44ad", "#f1c40f", "#e74c3c",
-                "#ecf0f1", "#bdc3c7", "#d35400", "#c0392b", "#7f8c8d"
-        };
-        Random random = new Random();
-        return colors[random.nextInt(colors.length)];
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
@@ -9,6 +9,7 @@ import com.kisesaki.blog.common.dto.PageResponse;
 import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCreateRequest;
 import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
 import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagUpdateRequest;
 import com.kisesaki.blog.content.tag.entity.Tags;
 import com.kisesaki.blog.content.tag.mapper.TagsMapper;
 import com.kisesaki.blog.content.tag.util.TagUtils;
@@ -94,5 +95,56 @@ public class AdminTagService {
         log.info("管理员用户 {} 创建了标签: {}", userId, tag.getName());
 
         return tag.getId();
+    }
+
+    /**
+     * 更新标签
+     *
+     * @param id      标签ID
+     * @param request 更新请求参数
+     * @param userId  操作用户ID
+     */
+    public void updateAdminTag(Long id, AdminTagUpdateRequest request, Long userId) {
+        Tags tag = tagsMapper.selectById(id);
+        if (tag == null) {
+            throw new IllegalArgumentException("标签不存在");
+        }
+
+        // 使用工具类验证和准备标签信息
+        TagUtils.TagValidationResult validationResult = tagUtils.validateAndPrepareTagInfo(
+                request.getName(),
+                request.getSlug(),
+                request.getColor());
+
+        tag.setName(validationResult.getName());
+        tag.setSlug(validationResult.getSlug());
+        tag.setDescription(request.getDescription());
+        tag.setColor(validationResult.getColor());
+        tag.setUpdatedAt(OffsetDateTime.now());
+
+        if (request.getIsApproved() != null) {
+            if (request.getIsApproved() && !tag.getIsApproved()) {
+                // 从未审核到审核通过
+                tag.setIsApproved(true);
+                tag.setApprovalStatus("approved");
+                tag.setApprovedBy(userId);
+                tag.setApprovedAt(OffsetDateTime.now());
+                tag.setApprovalNote(request.getApprovalNote());
+            } else if (!request.getIsApproved() && tag.getIsApproved()) {
+                // 从审核通过到未审核
+                tag.setIsApproved(false);
+                tag.setApprovalStatus("pending");
+                tag.setApprovedBy(null);
+                tag.setApprovedAt(null);
+                tag.setApprovalNote(null);
+            } else if (request.getIsApproved()) {
+                // 已审核状态下更新备注
+                tag.setApprovalNote(request.getApprovalNote());
+            }
+        }
+
+        tagsMapper.updateById(tag);
+
+        log.info("管理员用户 {} 更新了标签: {}", userId, tag.getName());
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
@@ -31,7 +31,7 @@ public class AdminTagService {
      * @param params 分页参数
      * @return 分页响应结果
      */
-    public PageResponse<AdminTagListResponse> getAdminTagList(AdminTagListParams params) {
+    public PageResponse<AdminTagListResponse> adminGetTagList(AdminTagListParams params) {
         // 构建分页对象
         Page<AdminTagListResponse> page = new Page<>(
                 params.getPageable().getCurrentPage(),
@@ -59,7 +59,7 @@ public class AdminTagService {
      * @param request 创建请求参数
      * @return 新创建标签的ID
      */
-    public Long createAdminTag(AdminTagCreateRequest request, Long userId) {
+    public Long adminTagCreate(AdminTagCreateRequest request, Long userId) {
         // 使用工具类验证和准备标签信息
         TagUtils.TagValidationResult validationResult = tagUtils.validateAndPrepareTagInfo(
                 request.getName(),
@@ -104,7 +104,7 @@ public class AdminTagService {
      * @param request 更新请求参数
      * @param userId  操作用户ID
      */
-    public void updateAdminTag(Long id, AdminTagUpdateRequest request, Long userId) {
+    public void adminTagUpdate(Long id, AdminTagUpdateRequest request, Long userId) {
         Tags tag = tagsMapper.selectById(id);
         if (tag == null) {
             throw new IllegalArgumentException("标签不存在");
@@ -147,4 +147,5 @@ public class AdminTagService {
 
         log.info("管理员用户 {} 更新了标签: {}", userId, tag.getName());
     }
+
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/AdminTagService.java
@@ -3,12 +3,20 @@ package com.kisesaki.blog.content.tag.service;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-import com.kisesaki.blog.common.exception.BusinessException;
-import com.kisesaki.blog.content.tag.dto.AdminCommand.*;
 import org.springframework.stereotype.Service;
 
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.kisesaki.blog.common.dto.PageResponse;
+import com.kisesaki.blog.common.exception.BusinessException;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagApprovalRequest;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCleanupResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagCreateRequest;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListParams;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagMergeRequest;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagPendingResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagUnusedResponse;
+import com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagUpdateRequest;
 import com.kisesaki.blog.content.tag.entity.Tags;
 import com.kisesaki.blog.content.tag.mapper.TagsMapper;
 import com.kisesaki.blog.content.tag.util.TagUtils;
@@ -204,5 +212,89 @@ public class AdminTagService {
      */
     public List<AdminTagPendingResponse> adminGetPendingTags() {
         return tagsMapper.getPendingTags();
+    }
+
+    /**
+     * 获取未使用的标签列表
+     *
+     * @param unusedDays 未使用的天数阈值，如果为null则获取所有未使用标签
+     * @return 未使用标签列表
+     */
+    public List<AdminTagUnusedResponse> adminGetUnusedTags(Integer unusedDays) {
+        return tagsMapper.getUnusedTags(unusedDays);
+    }
+
+    /**
+     * 清理未使用的标签
+     *
+     * @param unusedDays 未使用的天数阈值，默认30天
+     * @param userId     操作用户ID
+     * @return 清理结果
+     */
+    public AdminTagCleanupResponse adminCleanupUnusedTags(Integer unusedDays, Long userId) {
+        if (unusedDays == null) {
+            unusedDays = 30; // 默认30天
+        }
+
+        // 先获取将要被清理的标签数量
+        List<AdminTagUnusedResponse> unusedTags = tagsMapper.getUnusedTags(unusedDays);
+        int totalUnusedCount = unusedTags.size();
+
+        if (totalUnusedCount == 0) {
+            return new AdminTagCleanupResponse(0, 0, "没有找到需要清理的未使用标签");
+        }
+
+        // 执行清理
+        int cleanedCount = tagsMapper.deleteUnusedTags(unusedDays);
+
+        String message = String.format("已清理%d个超过%d天未使用的标签", cleanedCount, unusedDays);
+
+        log.info("管理员用户 {} 清理了 {} 个未使用标签，条件：超过{}天未使用", userId, cleanedCount, unusedDays);
+
+        return new AdminTagCleanupResponse(cleanedCount, totalUnusedCount, message);
+    }
+
+    /**
+     * 合并标签
+     *
+     * @param request 合并请求参数
+     * @param userId  操作用户ID
+     */
+    public void adminMergeTags(AdminTagMergeRequest request, Long userId) {
+        Long sourceTagId = request.getSourceTagId();
+        Long targetTagId = request.getTargetTagId();
+
+        // 验证标签存在性
+        Tags sourceTag = tagsMapper.selectById(sourceTagId);
+        if (sourceTag == null) {
+            throw BusinessException.notFound("源标签不存在");
+        }
+
+        Tags targetTag = tagsMapper.selectById(targetTagId);
+        if (targetTag == null) {
+            throw BusinessException.notFound("目标标签不存在");
+        }
+
+        if (sourceTagId.equals(targetTagId)) {
+            throw BusinessException.paramError("源标签和目标标签不能是同一个");
+        }
+
+        log.info("开始合并标签：源标签[{}:{}] -> 目标标签[{}:{}]", sourceTagId, sourceTag.getName(), targetTagId,
+                targetTag.getName());
+
+        // 1. 将源标签的所有文章关联转移到目标标签
+        int transferredPosts = tagsMapper.transferPostsFromSourceToTarget(sourceTagId, targetTagId);
+
+        // 2. 删除源标签的所有文章关联
+        tagsMapper.deletePostTagsByTagId(sourceTagId);
+
+        // 3. 更新目标标签的文章计数和最后使用时间
+        tagsMapper.updateTagPostCount(targetTagId);
+
+        // 4. 删除源标签
+        tagsMapper.deleteById(sourceTagId);
+
+        log.info("管理员用户 {} 成功合并标签：{} -> {}，转移了{}篇文章",
+                userId, sourceTag.getName(), targetTag.getName(), transferredPosts);
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/TagCommandService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/TagCommandService.java
@@ -1,0 +1,200 @@
+package com.kisesaki.blog.content.tag.service;
+
+import java.time.OffsetDateTime;
+import java.util.Random;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.kisesaki.blog.auth.security.user.CustomUserPrincipal;
+import com.kisesaki.blog.common.dto.PageResponse;
+import com.kisesaki.blog.common.enums.ErrorCode;
+import com.kisesaki.blog.common.exception.BusinessException;
+import com.kisesaki.blog.common.util.AuthUtils;
+import com.kisesaki.blog.common.util.PageQueryUtils;
+import com.kisesaki.blog.common.util.SlugUtils;
+import com.kisesaki.blog.content.tag.dto.TagCreateRequest;
+import com.kisesaki.blog.content.tag.dto.TagQuery.MyTagResponse;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
+import com.kisesaki.blog.content.tag.entity.Tags;
+import com.kisesaki.blog.content.tag.mapper.TagsMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 标签命令服务
+ * 负责处理标签的创建、更新、删除等写操作
+ * 
+ * @author KiseSaki
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TagCommandService {
+
+    private final TagsMapper tagsMapper;
+
+    /**
+     * 创建新标签（用户创作文章时）
+     * 
+     * @param request 创建标签请求
+     * @return 创建的标签信息
+     */
+    @Transactional
+    public Tags createTag(TagCreateRequest request) {
+        // 获取当前用户
+        CustomUserPrincipal currentUser = getCurrentUser();
+        
+        // 检查标签名称是否已存在
+        LambdaQueryWrapper<Tags> nameWrapper = new LambdaQueryWrapper<Tags>()
+                .eq(Tags::getName, request.getName());
+        if (tagsMapper.selectCount(nameWrapper) > 0) {
+            throw BusinessException.of(ErrorCode.PARAM_ERROR, "标签名称已存在");
+        }
+        
+        // 生成slug
+        String slug = request.getSlug();
+        if (slug == null || slug.trim().isEmpty()) {
+            slug = SlugUtils.generateSlug(request.getName());
+        }
+        
+        // 检查slug是否已存在
+        LambdaQueryWrapper<Tags> slugWrapper = new LambdaQueryWrapper<Tags>()
+                .eq(Tags::getSlug, slug);
+        if (tagsMapper.selectCount(slugWrapper) > 0) {
+            // 自动添加后缀避免冲突
+            slug = generateUniqueSlug(slug);
+        }
+        
+        // 生成颜色
+        String color = request.getColor();
+        if (color == null || color.trim().isEmpty()) {
+            color = generateRandomColor();
+        }
+        
+        // 创建标签实体
+        Tags tag = new Tags();
+        tag.setName(request.getName());
+        tag.setSlug(slug);
+        tag.setDescription(request.getDescription());
+        tag.setColor(color);
+        tag.setPostCount(0);
+        tag.setPopularityScore(0.0);
+        tag.setCreatedBy(currentUser.getId());
+        tag.setIsApproved(false); // 用户创建的标签需要审核
+        tag.setCreatedAt(OffsetDateTime.now());
+        tag.setUpdatedAt(OffsetDateTime.now());
+        
+        // 保存标签
+        tagsMapper.insert(tag);
+        
+        log.info("用户 {} 创建了标签: {}", currentUser.getUsername(), tag.getName());
+        
+        return tag;
+    }
+
+    /**
+     * 获取我创建的标签
+     * 
+     * @param params 查询参数
+     * @return 我创建的标签列表
+     */
+    public PageResponse<MyTagResponse> getMyTags(TagListParams params) {
+        CustomUserPrincipal currentUser = getCurrentUser();
+        
+        LambdaQueryWrapper<Tags> queryWrapper = new LambdaQueryWrapper<>();
+        
+        // 只查询当前用户创建的标签
+        queryWrapper.eq(Tags::getCreatedBy, currentUser.getId());
+        
+        // 标签名称模糊搜索
+        if (params.getName() != null && !params.getName().isEmpty()) {
+            queryWrapper.like(Tags::getName, params.getName());
+        }
+        
+        // 应用时间范围条件
+        PageQueryUtils.applyTimeRangeConditions(queryWrapper, params.getPageable(), Tags::getCreatedAt);
+        
+        // 应用排序规则
+        PageQueryUtils.createSortBuilder(queryWrapper, params.getPageable())
+                .defaultSort(Tags::getCreatedAt, true) // 默认按创建时间倒序
+                .addSortField("id", Tags::getId)
+                .addSortField("name", Tags::getName)
+                .addSortField("postCount", Tags::getPostCount)
+                .addSortField("createdAt", Tags::getCreatedAt)
+                .apply();
+        
+        // 执行分页查询
+        return PageQueryUtils.executePageQuery(
+                tagsMapper,
+                queryWrapper,
+                params.getPageable(),
+                this::convertToMyTagResponse);
+    }
+
+    /**
+     * 获取当前用户
+     */
+    private CustomUserPrincipal getCurrentUser() {
+        CustomUserPrincipal currentUser = AuthUtils.getCurrentUser();
+        if (currentUser == null) {
+            throw BusinessException.of(ErrorCode.UNAUTHORIZED, "用户未登录");
+        }
+        return currentUser;
+    }
+
+    /**
+     * 生成唯一的slug
+     */
+    private String generateUniqueSlug(String baseSlug) {
+        int counter = 1;
+        String candidateSlug = baseSlug + "-" + counter;
+        
+        while (tagsMapper.selectCount(new LambdaQueryWrapper<Tags>().eq(Tags::getSlug, candidateSlug)) > 0) {
+            counter++;
+            candidateSlug = baseSlug + "-" + counter;
+        }
+        
+        return candidateSlug;
+    }
+
+    /**
+     * 生成随机颜色
+     */
+    private String generateRandomColor() {
+        String[] colors = {
+            "#3498db", "#e74c3c", "#2ecc71", "#f39c12", "#9b59b6",
+            "#1abc9c", "#34495e", "#e67e22", "#95a5a6", "#16a085",
+            "#27ae60", "#2980b9", "#8e44ad", "#f1c40f", "#e74c3c",
+            "#ecf0f1", "#bdc3c7", "#d35400", "#c0392b", "#7f8c8d"
+        };
+        Random random = new Random();
+        return colors[random.nextInt(colors.length)];
+    }
+
+    /**
+     * 转换实体为我的标签响应对象
+     */
+    private MyTagResponse convertToMyTagResponse(Tags tag) {
+        MyTagResponse response = new MyTagResponse();
+        response.setId(tag.getId());
+        response.setName(tag.getName());
+        response.setSlug(tag.getSlug());
+        response.setDescription(tag.getDescription());
+        response.setColor(tag.getColor());
+        response.setPostCount(tag.getPostCount());
+        response.setCreatedAt(tag.getCreatedAt());
+        response.setIsApproved(tag.getIsApproved());
+        
+        // 设置审核状态
+        if (tag.getIsApproved() == null || !tag.getIsApproved()) {
+            response.setApprovalStatus("pending");
+        } else {
+            response.setApprovalStatus("approved");
+        }
+        
+        return response;
+    }
+}

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/TagCommandService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/TagCommandService.java
@@ -1,7 +1,6 @@
 package com.kisesaki.blog.content.tag.service;
 
 import java.time.OffsetDateTime;
-import java.util.Random;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,12 +12,12 @@ import com.kisesaki.blog.common.enums.ErrorCode;
 import com.kisesaki.blog.common.exception.BusinessException;
 import com.kisesaki.blog.common.util.AuthUtils;
 import com.kisesaki.blog.common.util.PageQueryUtils;
-import com.kisesaki.blog.common.util.SlugUtils;
 import com.kisesaki.blog.content.tag.dto.TagCreateRequest;
 import com.kisesaki.blog.content.tag.dto.TagQuery.MyTagResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
 import com.kisesaki.blog.content.tag.entity.Tags;
 import com.kisesaki.blog.content.tag.mapper.TagsMapper;
+import com.kisesaki.blog.content.tag.util.TagUtils;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 public class TagCommandService {
 
     private final TagsMapper tagsMapper;
+    private final TagUtils tagUtils;
 
     /**
      * 创建新标签（用户创作文章时）
@@ -46,52 +46,31 @@ public class TagCommandService {
     public Tags createTag(TagCreateRequest request) {
         // 获取当前用户
         CustomUserPrincipal currentUser = getCurrentUser();
-        
-        // 检查标签名称是否已存在
-        LambdaQueryWrapper<Tags> nameWrapper = new LambdaQueryWrapper<Tags>()
-                .eq(Tags::getName, request.getName());
-        if (tagsMapper.selectCount(nameWrapper) > 0) {
-            throw BusinessException.of(ErrorCode.PARAM_ERROR, "标签名称已存在");
-        }
-        
-        // 生成slug
-        String slug = request.getSlug();
-        if (slug == null || slug.trim().isEmpty()) {
-            slug = SlugUtils.generateSlug(request.getName());
-        }
-        
-        // 检查slug是否已存在
-        LambdaQueryWrapper<Tags> slugWrapper = new LambdaQueryWrapper<Tags>()
-                .eq(Tags::getSlug, slug);
-        if (tagsMapper.selectCount(slugWrapper) > 0) {
-            // 自动添加后缀避免冲突
-            slug = generateUniqueSlug(slug);
-        }
-        
-        // 生成颜色
-        String color = request.getColor();
-        if (color == null || color.trim().isEmpty()) {
-            color = generateRandomColor();
-        }
-        
+
+        // 使用工具类验证和准备标签信息
+        TagUtils.TagValidationResult validationResult = tagUtils.validateAndPrepareTagInfo(
+                request.getName(),
+                request.getSlug(),
+                request.getColor());
+
         // 创建标签实体
         Tags tag = new Tags();
-        tag.setName(request.getName());
-        tag.setSlug(slug);
+        tag.setName(validationResult.getName());
+        tag.setSlug(validationResult.getSlug());
         tag.setDescription(request.getDescription());
-        tag.setColor(color);
+        tag.setColor(validationResult.getColor());
         tag.setPostCount(0);
         tag.setPopularityScore(0.0);
         tag.setCreatedBy(currentUser.getId());
         tag.setIsApproved(false); // 用户创建的标签需要审核
         tag.setCreatedAt(OffsetDateTime.now());
         tag.setUpdatedAt(OffsetDateTime.now());
-        
+
         // 保存标签
         tagsMapper.insert(tag);
-        
+
         log.info("用户 {} 创建了标签: {}", currentUser.getUsername(), tag.getName());
-        
+
         return tag;
     }
 
@@ -103,20 +82,20 @@ public class TagCommandService {
      */
     public PageResponse<MyTagResponse> getMyTags(TagListParams params) {
         CustomUserPrincipal currentUser = getCurrentUser();
-        
+
         LambdaQueryWrapper<Tags> queryWrapper = new LambdaQueryWrapper<>();
-        
+
         // 只查询当前用户创建的标签
         queryWrapper.eq(Tags::getCreatedBy, currentUser.getId());
-        
+
         // 标签名称模糊搜索
         if (params.getName() != null && !params.getName().isEmpty()) {
             queryWrapper.like(Tags::getName, params.getName());
         }
-        
+
         // 应用时间范围条件
         PageQueryUtils.applyTimeRangeConditions(queryWrapper, params.getPageable(), Tags::getCreatedAt);
-        
+
         // 应用排序规则
         PageQueryUtils.createSortBuilder(queryWrapper, params.getPageable())
                 .defaultSort(Tags::getCreatedAt, true) // 默认按创建时间倒序
@@ -125,7 +104,7 @@ public class TagCommandService {
                 .addSortField("postCount", Tags::getPostCount)
                 .addSortField("createdAt", Tags::getCreatedAt)
                 .apply();
-        
+
         // 执行分页查询
         return PageQueryUtils.executePageQuery(
                 tagsMapper,
@@ -146,35 +125,6 @@ public class TagCommandService {
     }
 
     /**
-     * 生成唯一的slug
-     */
-    private String generateUniqueSlug(String baseSlug) {
-        int counter = 1;
-        String candidateSlug = baseSlug + "-" + counter;
-        
-        while (tagsMapper.selectCount(new LambdaQueryWrapper<Tags>().eq(Tags::getSlug, candidateSlug)) > 0) {
-            counter++;
-            candidateSlug = baseSlug + "-" + counter;
-        }
-        
-        return candidateSlug;
-    }
-
-    /**
-     * 生成随机颜色
-     */
-    private String generateRandomColor() {
-        String[] colors = {
-            "#3498db", "#e74c3c", "#2ecc71", "#f39c12", "#9b59b6",
-            "#1abc9c", "#34495e", "#e67e22", "#95a5a6", "#16a085",
-            "#27ae60", "#2980b9", "#8e44ad", "#f1c40f", "#e74c3c",
-            "#ecf0f1", "#bdc3c7", "#d35400", "#c0392b", "#7f8c8d"
-        };
-        Random random = new Random();
-        return colors[random.nextInt(colors.length)];
-    }
-
-    /**
      * 转换实体为我的标签响应对象
      */
     private MyTagResponse convertToMyTagResponse(Tags tag) {
@@ -187,14 +137,14 @@ public class TagCommandService {
         response.setPostCount(tag.getPostCount());
         response.setCreatedAt(tag.getCreatedAt());
         response.setIsApproved(tag.getIsApproved());
-        
+
         // 设置审核状态
         if (tag.getIsApproved() == null || !tag.getIsApproved()) {
             response.setApprovalStatus("pending");
         } else {
             response.setApprovalStatus("approved");
         }
-        
+
         return response;
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/TagQueryService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/TagQueryService.java
@@ -1,4 +1,4 @@
-package com.kisesaki.blog.content.tag;
+package com.kisesaki.blog.content.tag.service;
 
 import java.util.List;
 
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class TagService {
+public class TagQueryService {
 
     private final TagsMapper tagsMapper;
 

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/TagQueryService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/TagQueryService.java
@@ -12,10 +12,13 @@ import com.kisesaki.blog.content.tag.dto.TagQuery.TagCloudItem;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListResponse;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagPostsParams;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagSearchItem;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagSearchParams;
+import com.kisesaki.blog.content.post.dto.PostQuery.PublishedPostListResponse;
 import com.kisesaki.blog.content.tag.entity.Tags;
 import com.kisesaki.blog.content.tag.mapper.TagsMapper;
+import com.kisesaki.blog.content.post.service.PostQueryService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 public class TagQueryService {
 
     private final TagsMapper tagsMapper;
+    private final PostQueryService postQueryService;
 
     /**
      * 获取标签列表
@@ -267,6 +271,17 @@ public class TagQueryService {
         }
         
         return Math.min(1.0, score);
+    }
+
+    /**
+     * 获取指定标签下的文章列表
+     * 
+     * @param tagId 标签ID
+     * @param params 查询参数
+     * @return 文章列表
+     */
+    public PageResponse<PublishedPostListResponse> getTagPosts(Long tagId, TagPostsParams params) {
+        return postQueryService.selectPostsByTag(tagId, params);
     }
 
     /**

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/TagQueryService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/service/TagQueryService.java
@@ -12,6 +12,8 @@ import com.kisesaki.blog.content.tag.dto.TagQuery.TagCloudItem;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListParams;
 import com.kisesaki.blog.content.tag.dto.TagQuery.TagListResponse;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagSearchItem;
+import com.kisesaki.blog.content.tag.dto.TagQuery.TagSearchParams;
 import com.kisesaki.blog.content.tag.entity.Tags;
 import com.kisesaki.blog.content.tag.mapper.TagsMapper;
 
@@ -155,6 +157,116 @@ public class TagQueryService {
             log.error("获取标签云失败", e);
             throw new RuntimeException("获取标签云失败，请稍后重试");
         }
+    }
+
+    /**
+     * 搜索标签
+     * 
+     * @param params 搜索参数
+     * @return 搜索结果列表
+     */
+    public List<TagSearchItem> searchTags(TagSearchParams params) {
+        try {
+            LambdaQueryWrapper<Tags> queryWrapper = new LambdaQueryWrapper<>();
+            
+            // 搜索关键词
+            if (params.getQ() != null && !params.getQ().trim().isEmpty()) {
+                String keyword = params.getQ().trim();
+                queryWrapper.and(wrapper -> wrapper
+                    .like(Tags::getName, keyword)
+                    .or()
+                    .like(Tags::getDescription, keyword)
+                );
+            }
+            
+            // 是否只显示已审核通过的标签
+            if (params.getApprovedOnly() != null && params.getApprovedOnly()) {
+                queryWrapper.eq(Tags::getIsApproved, true);
+            }
+            
+            // 排序
+            switch (params.getSort()) {
+                case "name":
+                    queryWrapper.orderByAsc(Tags::getName);
+                    break;
+                case "created_at":
+                    queryWrapper.orderByDesc(Tags::getCreatedAt);
+                    break;
+                case "popularity":
+                default:
+                    queryWrapper.orderByDesc(Tags::getPopularityScore)
+                              .orderByDesc(Tags::getPostCount);
+                    break;
+            }
+            
+            // 限制返回数量
+            queryWrapper.last("LIMIT " + Math.min(params.getLimit(), 50));
+            
+            List<Tags> tags = tagsMapper.selectList(queryWrapper);
+            
+            return tags.stream().map(tag -> {
+                TagSearchItem item = new TagSearchItem();
+                item.setId(tag.getId());
+                item.setName(tag.getName());
+                item.setSlug(tag.getSlug());
+                item.setDescription(tag.getDescription());
+                item.setColor(tag.getColor());
+                item.setPostCount(tag.getPostCount());
+                
+                // 计算匹配得分（简化版本，实际可以更复杂）
+                double matchScore = calculateMatchScore(tag, params.getQ());
+                item.setMatchScore(matchScore);
+                
+                return item;
+            }).toList();
+            
+        } catch (Exception e) {
+            log.error("搜索标签失败", e);
+            throw new RuntimeException("搜索标签失败，请稍后重试");
+        }
+    }
+
+    /**
+     * 计算匹配得分（简化版本）
+     */
+    private double calculateMatchScore(Tags tag, String keyword) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return 1.0;
+        }
+        
+        String lowerKeyword = keyword.toLowerCase();
+        String lowerName = tag.getName().toLowerCase();
+        String lowerDesc = tag.getDescription() != null ? tag.getDescription().toLowerCase() : "";
+        
+        double score = 0.0;
+        
+        // 名称完全匹配得分最高
+        if (lowerName.equals(lowerKeyword)) {
+            score = 1.0;
+        } 
+        // 名称开头匹配
+        else if (lowerName.startsWith(lowerKeyword)) {
+            score = 0.8;
+        }
+        // 名称包含关键词
+        else if (lowerName.contains(lowerKeyword)) {
+            score = 0.6;
+        }
+        // 描述包含关键词
+        else if (lowerDesc.contains(lowerKeyword)) {
+            score = 0.4;
+        }
+        // 默认得分
+        else {
+            score = 0.1;
+        }
+        
+        // 根据流行度调整得分
+        if (tag.getPopularityScore() != null && tag.getPopularityScore() > 0) {
+            score *= (1 + Math.log10(tag.getPopularityScore()) / 10);
+        }
+        
+        return Math.min(1.0, score);
     }
 
     /**

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/util/TagUtils.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/util/TagUtils.java
@@ -1,0 +1,164 @@
+package com.kisesaki.blog.content.tag.util;
+
+import java.util.Random;
+
+import org.springframework.stereotype.Component;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.kisesaki.blog.common.enums.ErrorCode;
+import com.kisesaki.blog.common.exception.BusinessException;
+import com.kisesaki.blog.common.util.SlugUtils;
+import com.kisesaki.blog.content.tag.entity.Tags;
+import com.kisesaki.blog.content.tag.mapper.TagsMapper;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 标签工具类
+ * 提供标签相关的通用方法，避免代码重复
+ * 
+ * @author KiseSaki
+ */
+@Component
+@RequiredArgsConstructor
+public class TagUtils {
+
+    private final TagsMapper tagsMapper;
+
+    /**
+     * 预定义的标签颜色数组
+     */
+    private static final String[] TAG_COLORS = {
+            "#3498db", "#e74c3c", "#2ecc71", "#f39c12", "#9b59b6",
+            "#1abc9c", "#34495e", "#e67e22", "#95a5a6", "#16a085",
+            "#27ae60", "#2980b9", "#8e44ad", "#f1c40f", "#e74c3c",
+            "#ecf0f1", "#bdc3c7", "#d35400", "#c0392b", "#7f8c8d"
+    };
+
+    /**
+     * 验证标签名称是否已存在
+     * 
+     * @param name 标签名称
+     * @throws BusinessException 如果名称已存在
+     */
+    public void validateTagNameUnique(String name) {
+        LambdaQueryWrapper<Tags> wrapper = new LambdaQueryWrapper<Tags>()
+                .eq(Tags::getName, name);
+        if (tagsMapper.selectCount(wrapper) > 0) {
+            throw BusinessException.of(ErrorCode.PARAM_ERROR, "标签名称已存在");
+        }
+    }
+
+    /**
+     * 验证并生成唯一的 slug
+     * 
+     * @param requestSlug 请求中的 slug（可能为空）
+     * @param tagName     标签名称（用于生成默认 slug）
+     * @return 唯一的 slug
+     */
+    public String generateUniqueSlug(String requestSlug, String tagName) {
+        String slug = requestSlug;
+        if (slug == null || slug.trim().isEmpty()) {
+            slug = SlugUtils.generateSlug(tagName);
+        }
+
+        // 检查 slug 是否已存在
+        LambdaQueryWrapper<Tags> wrapper = new LambdaQueryWrapper<Tags>()
+                .eq(Tags::getSlug, slug);
+        if (tagsMapper.selectCount(wrapper) > 0) {
+            // 自动添加后缀避免冲突
+            slug = generateUniqueSlugWithSuffix(slug);
+        }
+
+        return slug;
+    }
+
+    /**
+     * 生成唯一的 slug（带数字后缀）
+     * 
+     * @param baseSlug 基础 slug
+     * @return 唯一的 slug
+     */
+    private String generateUniqueSlugWithSuffix(String baseSlug) {
+        int counter = 1;
+        String candidateSlug = baseSlug + "-" + counter;
+
+        while (tagsMapper.selectCount(new LambdaQueryWrapper<Tags>().eq(Tags::getSlug, candidateSlug)) > 0) {
+            counter++;
+            candidateSlug = baseSlug + "-" + counter;
+        }
+
+        return candidateSlug;
+    }
+
+    /**
+     * 生成随机颜色
+     * 
+     * @param requestColor 请求中的颜色（可能为空）
+     * @return 颜色值
+     */
+    public String generateColor(String requestColor) {
+        if (requestColor != null && !requestColor.trim().isEmpty()) {
+            return requestColor;
+        }
+
+        Random random = new Random();
+        return TAG_COLORS[random.nextInt(TAG_COLORS.length)];
+    }
+
+    /**
+     * 生成随机颜色（不检查请求参数）
+     * 
+     * @return 随机颜色值
+     */
+    public String generateRandomColor() {
+        Random random = new Random();
+        return TAG_COLORS[random.nextInt(TAG_COLORS.length)];
+    }
+
+    /**
+     * 验证标签创建的基础信息
+     * 
+     * @param name 标签名称
+     * @return 验证通过的标签信息对象
+     */
+    public TagValidationResult validateAndPrepareTagInfo(String name, String requestSlug, String requestColor) {
+        // 验证名称唯一性
+        validateTagNameUnique(name);
+
+        // 生成唯一 slug
+        String slug = generateUniqueSlug(requestSlug, name);
+
+        // 生成颜色
+        String color = generateColor(requestColor);
+
+        return new TagValidationResult(name, slug, color);
+    }
+
+    /**
+     * 标签验证结果
+     */
+    public static class TagValidationResult {
+        private final String name;
+        private final String slug;
+        private final String color;
+
+        public TagValidationResult(String name, String slug, String color) {
+            this.name = name;
+            this.slug = slug;
+            this.color = color;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getSlug() {
+            return slug;
+        }
+
+        public String getColor() {
+            return color;
+        }
+    }
+}

--- a/backend/blog-backend/src/main/resources/db/migration/V7__update_tags_table_add_approval_fields.sql
+++ b/backend/blog-backend/src/main/resources/db/migration/V7__update_tags_table_add_approval_fields.sql
@@ -1,0 +1,111 @@
+-- V7__update_tags_table_add_approval_fields.sql
+-- Flyway migration: Update tags table to support approval workflow and enhanced features
+-- Generated based on tag management API requirements
+
+-- 添加新字段到 tags 表
+ALTER TABLE tags
+ADD COLUMN updated_at TIMESTAMPTZ DEFAULT now(),
+ADD COLUMN created_by BIGINT,
+ADD COLUMN is_approved BOOLEAN DEFAULT FALSE,
+ADD COLUMN approval_status VARCHAR(20) DEFAULT 'pending',
+ADD COLUMN approved_by BIGINT,
+ADD COLUMN approved_at TIMESTAMPTZ,
+ADD COLUMN approval_note VARCHAR(500),
+ADD COLUMN last_used_at TIMESTAMPTZ,
+ADD COLUMN popularity_score DOUBLE PRECISION DEFAULT 0.0;
+
+-- 添加约束：审核状态只能是指定值
+ALTER TABLE tags
+ADD CONSTRAINT ck_tags_approval_status CHECK (
+    approval_status IN (
+        'pending',
+        'approved',
+        'rejected'
+    )
+);
+
+-- 创建索引以提高查询性能
+CREATE INDEX IF NOT EXISTS ix_tags_created_by ON tags (created_by);
+
+CREATE INDEX IF NOT EXISTS ix_tags_approval_status ON tags (approval_status);
+
+CREATE INDEX IF NOT EXISTS ix_tags_approved_by ON tags (approved_by);
+
+CREATE INDEX IF NOT EXISTS ix_tags_is_approved ON tags (is_approved);
+
+CREATE INDEX IF NOT EXISTS ix_tags_last_used_at ON tags (last_used_at);
+
+CREATE INDEX IF NOT EXISTS ix_tags_popularity_score ON tags (popularity_score DESC);
+
+CREATE INDEX IF NOT EXISTS ix_tags_name ON tags (name);
+
+-- 添加外键约束：关联用户表
+ALTER TABLE tags
+ADD CONSTRAINT fk_tags_created_by_user FOREIGN KEY (created_by) REFERENCES "user" (id) ON DELETE SET NULL;
+
+ALTER TABLE tags
+ADD CONSTRAINT fk_tags_approved_by_user FOREIGN KEY (approved_by) REFERENCES "user" (id) ON DELETE SET NULL;
+
+-- 更新现有数据：将所有现有标签设为已审核通过
+UPDATE tags
+SET
+    updated_at = now(),
+    is_approved = TRUE,
+    approval_status = 'approved',
+    approved_at = created_at,
+    last_used_at = created_at,
+    popularity_score = COALESCE(post_count * 1.0, 0.0)
+WHERE
+    id IS NOT NULL;
+
+-- 创建触发器函数：自动更新 updated_at 字段
+CREATE OR REPLACE FUNCTION update_tags_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 创建触发器：在更新时自动更新 updated_at
+CREATE TRIGGER tr_tags_update_updated_at
+    BEFORE UPDATE ON tags
+    FOR EACH ROW
+    EXECUTE FUNCTION update_tags_updated_at();
+
+-- 创建触发器函数：自动更新热度权重
+CREATE OR REPLACE FUNCTION update_tag_popularity_score()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- 基于文章数量计算热度权重，可以根据需要调整算法
+    NEW.popularity_score = COALESCE(NEW.post_count * 1.0, 0.0);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 创建触发器：在更新 post_count 时自动更新热度权重
+CREATE TRIGGER tr_tags_update_popularity_score
+    BEFORE UPDATE OF post_count ON tags
+    FOR EACH ROW
+    EXECUTE FUNCTION update_tag_popularity_score();
+
+-- 添加注释
+COMMENT ON COLUMN tags.updated_at IS '标签更新时间';
+
+COMMENT ON COLUMN tags.created_by IS '创建者用户ID';
+
+COMMENT ON COLUMN tags.is_approved IS '是否已审核通过';
+
+COMMENT ON COLUMN tags.approval_status IS '审核状态：pending-待审核, approved-已通过, rejected-已拒绝';
+
+COMMENT ON COLUMN tags.approved_by IS '审核者用户ID';
+
+COMMENT ON COLUMN tags.approved_at IS '审核时间';
+
+COMMENT ON COLUMN tags.approval_note IS '审核备注';
+
+COMMENT ON COLUMN tags.last_used_at IS '最近使用时间（最后一次被文章使用的时间）';
+
+COMMENT ON COLUMN tags.popularity_score IS '热度权重（基于文章数量、阅读量等计算）';
+
+-- End of migration

--- a/backend/blog-backend/src/main/resources/mapper/content/post/PostsMapper.xml
+++ b/backend/blog-backend/src/main/resources/mapper/content/post/PostsMapper.xml
@@ -1188,4 +1188,89 @@
         FROM posts p
         WHERE p.status != 'deleted'  -- 排除已删除的文章
     </select>
+
+    <!-- 分页查询指定标签下的已发布文章 -->
+    <select id="selectPostsByTagPage" resultMap="PublishedPostListMap">
+        SELECT DISTINCT
+            p.id AS post_id,
+            p.title AS post_title,
+            p.slug AS post_slug,
+            p.excerpt AS post_excerpt,
+            p.cover_image_url AS post_cover_image_url,
+            p.view_count AS post_view_count,
+            p.like_count AS post_like_count,
+            p.comment_count AS post_comment_count,
+            p.share_count AS post_share_count,
+            p.reading_time AS post_reading_time,
+            p.is_featured AS post_is_featured,
+            p.is_top AS post_is_top,
+            p.published_at AS post_published_at,
+
+            -- 作者信息
+            u.id AS author_id,
+            u.username AS author_username,
+            u.display_name AS author_display_name,
+            u.avatar_url AS author_avatar_url,
+            u.bio AS author_bio,
+
+            -- 分类信息
+            c.id AS category_id,
+            c.name AS category_name,
+            c.slug AS category_slug,
+            c.description AS category_description,
+
+            -- 标签信息（返回所有标签，不仅是查询的标签）
+            t.id AS tag_id,
+            t.name AS tag_name,
+            t.slug AS tag_slug,
+            t.color AS tag_color
+
+        FROM posts p
+        INNER JOIN "user" u ON p.author_id = u.id
+        LEFT JOIN categories c ON p.category_id = c.id
+        INNER JOIN post_tags pt ON p.id = pt.post_id
+        LEFT JOIN post_tags pt_all ON p.id = pt_all.post_id
+        LEFT JOIN tags t ON pt_all.tag_id = t.id
+
+        WHERE p.status = #{params.status}
+          AND p.visibility = #{params.visibility}
+          AND pt.tag_id = #{tagId}
+          <if test="params.featuredOnly != null and params.featuredOnly">
+              AND p.is_featured = true
+          </if>
+
+        ORDER BY 
+        <choose>
+            <when test="params.pageable.sort != null and params.pageable.sort != ''">
+                <if test="params.pageable.sort.contains('publishedAt')">
+                    p.published_at <if test="params.pageable.sortDirection == 'desc'">DESC</if><if test="params.pageable.sortDirection != 'desc'">ASC</if>
+                </if>
+                <if test="params.pageable.sort.contains('viewCount')">
+                    p.view_count <if test="params.pageable.sortDirection == 'desc'">DESC</if><if test="params.pageable.sortDirection != 'desc'">ASC</if>
+                </if>
+                <if test="params.pageable.sort.contains('likeCount')">
+                    p.like_count <if test="params.pageable.sortDirection == 'desc'">DESC</if><if test="params.pageable.sortDirection != 'desc'">ASC</if>
+                </if>
+                <if test="params.pageable.sort.contains('title')">
+                    p.title <if test="params.pageable.sortDirection == 'desc'">DESC</if><if test="params.pageable.sortDirection != 'desc'">ASC</if>
+                </if>
+            </when>
+            <otherwise>
+                p.published_at DESC
+            </otherwise>
+        </choose>
+    </select>
+
+    <!-- 计算指定标签下的已发布文章数量 -->
+    <select id="countPostsByTag" resultType="long">
+        SELECT COUNT(DISTINCT p.id)
+        FROM posts p
+        INNER JOIN post_tags pt ON p.id = pt.post_id
+        WHERE p.status = #{params.status}
+          AND p.visibility = #{params.visibility}
+          AND pt.tag_id = #{tagId}
+          <if test="params.featuredOnly != null and params.featuredOnly">
+              AND p.is_featured = true
+          </if>
+    </select>
 </mapper>

--- a/backend/blog-backend/src/main/resources/mapper/content/tag/TagsMapper.xml
+++ b/backend/blog-backend/src/main/resources/mapper/content/tag/TagsMapper.xml
@@ -38,4 +38,26 @@
         WHERE
             t.id = #{id}
     </select>
+
+    <!-- 根据Slug查询标签详情 -->
+    <select id="getTagDetailBySlug" resultMap="TagDetailResponse" parameterType="string">
+        SELECT
+            t.id,
+            t.name AS tag_name,
+            t.slug AS tag_slug,
+            t.description AS tag_description,
+            t.color AS tag_color,
+            t.post_count AS tag_post_count,
+            t.created_at AS tag_created_at,
+            t.updated_at AS tag_updated_at,
+            t.created_by AS tag_created_by,
+            u.username AS user_username,
+            t.is_approved AS tag_is_approved
+        FROM
+            tags t
+        LEFT JOIN
+            "user" u ON t.created_by = u.id
+        WHERE
+            t.slug = #{slug}
+    </select>
 </mapper>

--- a/backend/blog-backend/src/main/resources/mapper/content/tag/TagsMapper.xml
+++ b/backend/blog-backend/src/main/resources/mapper/content/tag/TagsMapper.xml
@@ -60,4 +60,100 @@
         WHERE
             t.slug = #{slug}
     </select>
+
+    <!-- 获取管理员标签列表 -->
+    <select id="getAdminTagList" resultType="com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagListResponse">
+        SELECT
+            t.id,
+            t.name,
+            t.slug,
+            t.description,
+            t.color,
+            t.post_count,
+            t.created_at,
+            t.updated_at,
+            t.created_by,
+            uc.username AS created_by_username,
+            t.is_approved,
+            t.approval_status,
+            t.approved_by,
+            ua.username AS approved_by_username,
+            t.approved_at,
+            t.approval_note,
+            t.last_used_at,
+            t.popularity_score
+        FROM tags t
+        LEFT JOIN "user" uc ON t.created_by = uc.id
+        LEFT JOIN "user" ua ON t.approved_by = ua.id
+        <where>
+            <if test="params.name != null and params.name != ''">
+                AND t.name LIKE concat('%', #{params.name}, '%')
+            </if>
+            <if test="params.approvalStatus != null">
+                AND t.approval_status = #{params.approvalStatus}
+            </if>
+            <if test="params.createdBy != null">
+                AND t.created_by = #{params.createdBy}
+            </if>
+            <if test="params.unusedOnly != null and params.unusedOnly">
+                AND t.post_count = 0
+            </if>
+            <if test="params.unusedOnly == null or !params.unusedOnly">
+                <if test="params.minPostCount != null">
+                    AND t.post_count >= #{params.minPostCount}
+                </if>
+                <if test="params.maxPostCount != null">
+                    AND t.post_count &lt;= #{params.maxPostCount}
+                </if>
+            </if>
+            <!-- 时间范围筛选 -->
+            <if test="params.pageable.startTime != null">
+                AND t.created_at >= #{params.pageable.startTime}
+            </if>
+            <if test="params.pageable.endTime != null">
+                AND t.created_at &lt;= #{params.pageable.endTime}
+            </if>
+            <if test="params.pageable.date != null">
+                AND DATE(t.created_at) = #{params.pageable.date}
+            </if>
+        </where>
+        <!-- 动态排序 -->
+        ORDER BY
+        <choose>
+            <when test="params.pageable.getSortField() != null and params.pageable.getSortField() != ''">
+                <choose>
+                    <when test="params.pageable.getSortField() == 'id'">t.id</when>
+                    <when test="params.pageable.getSortField() == 'name'">t.name</when>
+                    <when test="params.pageable.getSortField() == 'postCount'">t.post_count</when>
+                    <when test="params.pageable.getSortField() == 'post_count'">t.post_count</when>
+                    <when test="params.pageable.getSortField() == 'createdAt'">t.created_at</when>
+                    <when test="params.pageable.getSortField() == 'created_at'">t.created_at</when>
+                    <when test="params.pageable.getSortField() == 'updatedAt'">t.updated_at</when>
+                    <when test="params.pageable.getSortField() == 'updated_at'">t.updated_at</when>
+                    <when test="params.pageable.getSortField() == 'createdBy'">t.created_by</when>
+                    <when test="params.pageable.getSortField() == 'created_by'">t.created_by</when>
+                    <when test="params.pageable.getSortField() == 'isApproved'">t.is_approved</when>
+                    <when test="params.pageable.getSortField() == 'is_approved'">t.is_approved</when>
+                    <when test="params.pageable.getSortField() == 'approvalStatus'">t.approval_status</when>
+                    <when test="params.pageable.getSortField() == 'approval_status'">t.approval_status</when>
+                    <when test="params.pageable.getSortField() == 'approvedBy'">t.approved_by</when>
+                    <when test="params.pageable.getSortField() == 'approved_by'">t.approved_by</when>
+                    <when test="params.pageable.getSortField() == 'approvedAt'">t.approved_at</when>
+                    <when test="params.pageable.getSortField() == 'approved_at'">t.approved_at</when>
+                    <when test="params.pageable.getSortField() == 'lastUsedAt'">t.last_used_at</when>
+                    <when test="params.pageable.getSortField() == 'last_used_at'">t.last_used_at</when>
+                    <when test="params.pageable.getSortField() == 'popularityScore'">t.popularity_score</when>
+                    <when test="params.pageable.getSortField() == 'popularity_score'">t.popularity_score</when>
+                    <otherwise>t.created_at</otherwise>
+                </choose>
+                <choose>
+                    <when test="params.pageable.isDescending()">DESC</when>
+                    <otherwise>ASC</otherwise>
+                </choose>
+            </when>
+            <otherwise>
+                t.created_at DESC
+            </otherwise>
+        </choose>
+    </select>
 </mapper>

--- a/backend/blog-backend/src/main/resources/mapper/content/tag/TagsMapper.xml
+++ b/backend/blog-backend/src/main/resources/mapper/content/tag/TagsMapper.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.kisesaki.blog.content.tag.mapper.TagsMapper">
+    <resultMap id="TagDetailResponse" type="com.kisesaki.blog.content.tag.dto.TagQuery.TagDetailResponse">
+        <id property="id" column="id"/>
+        <result property="name" column="tag_name"/>
+        <result property="slug" column="tag_slug"/>
+        <result property="description" column="tag_description"/>
+        <result property="color" column="tag_color"/>
+        <result property="postCount" column="tag_post_count"/>
+        <result property="createdAt" column="tag_created_at"/>
+        <result property="updatedAt" column="tag_updated_at"/>
+        <result property="createdBy" column="tag_created_by"/>
+        <result property="createdByUsername" column="user_username"/>
+        <result property="isApproved" column="tag_is_approved"/>
+    </resultMap>
+
+    <!-- 根据Id查询标签详情 -->
+    <select id="getTagDetailById" resultMap="TagDetailResponse" parameterType="long">
+        SELECT
+            t.id,
+            t.name AS tag_name,
+            t.slug AS tag_slug,
+            t.description AS tag_description,
+            t.color AS tag_color,
+            t.post_count AS tag_post_count,
+            t.created_at AS tag_created_at,
+            t.updated_at AS tag_updated_at,
+            t.created_by AS tag_created_by,
+            u.username AS user_username,
+            t.is_approved AS tag_is_approved
+        FROM
+            tags t
+        LEFT JOIN
+            "user" u ON t.created_by = u.id
+        WHERE
+            t.id = #{id}
+    </select>
+</mapper>

--- a/backend/blog-backend/src/main/resources/mapper/content/tag/TagsMapper.xml
+++ b/backend/blog-backend/src/main/resources/mapper/content/tag/TagsMapper.xml
@@ -173,4 +173,74 @@
         WHERE t.approval_status = 'PENDING'
         ORDER BY t.created_at DESC
     </select>
+
+    <!-- 获取未使用的标签列表 -->
+    <select id="getUnusedTags" resultType="com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagUnusedResponse">
+        SELECT
+            t.id,
+            t.name,
+            t.slug,
+            t.description,
+            t.color,
+            t.created_at,
+            t.created_by,
+            u.username AS created_by_username,
+            COALESCE(EXTRACT(DAY FROM (now() - COALESCE(t.last_used_at, t.created_at))), 0) AS unused_days,
+            t.is_approved
+        FROM tags t
+        LEFT JOIN "user" u ON t.created_by = u.id
+        WHERE t.post_count = 0
+        <if test="unusedDays != null and unusedDays > 0">
+            AND COALESCE(EXTRACT(DAY FROM (now() - COALESCE(t.last_used_at, t.created_at))), 0) >= #{unusedDays}
+        </if>
+        ORDER BY t.created_at ASC
+    </select>
+
+    <!-- 删除未使用的标签 -->
+    <delete id="deleteUnusedTags">
+        DELETE FROM tags
+        WHERE post_count = 0
+        <if test="unusedDays != null and unusedDays > 0">
+            AND COALESCE(EXTRACT(DAY FROM (now() - COALESCE(last_used_at, created_at))), 0) >= #{unusedDays}
+        </if>
+    </delete>
+
+    <!-- 将源标签的所有文章转移到目标标签 -->
+    <insert id="transferPostsFromSourceToTarget">
+        INSERT INTO post_tags (post_id, tag_id, created_at)
+        SELECT DISTINCT pt.post_id, #{targetTagId}, pt.created_at
+        FROM post_tags pt
+        WHERE pt.tag_id = #{sourceTagId}
+        AND NOT EXISTS (
+            SELECT 1 FROM post_tags pt2
+            WHERE pt2.post_id = pt.post_id
+            AND pt2.tag_id = #{targetTagId}
+        )
+        ON CONFLICT (post_id, tag_id) DO NOTHING
+    </insert>
+
+    <!-- 删除指定标签的所有文章关联 -->
+    <delete id="deletePostTagsByTagId">
+        DELETE FROM post_tags
+        WHERE tag_id = #{tagId}
+    </delete>
+
+    <!-- 更新标签的文章计数 -->
+    <update id="updateTagPostCount">
+        UPDATE tags
+        SET post_count = (
+            SELECT COUNT(*)
+            FROM post_tags pt
+            WHERE pt.tag_id = #{tagId}
+        ),
+        last_used_at = (
+            SELECT MAX(p.published_at)
+            FROM post_tags pt
+            JOIN posts p ON pt.post_id = p.id
+            WHERE pt.tag_id = #{tagId}
+            AND p.status = 'published'
+        ),
+        updated_at = now()
+        WHERE id = #{tagId}
+    </update>
 </mapper>

--- a/backend/blog-backend/src/main/resources/mapper/content/tag/TagsMapper.xml
+++ b/backend/blog-backend/src/main/resources/mapper/content/tag/TagsMapper.xml
@@ -156,4 +156,21 @@
             </otherwise>
         </choose>
     </select>
+
+    <!-- 获取所有待审核标签 -->
+    <select id="getPendingTags" resultType="com.kisesaki.blog.content.tag.dto.AdminCommand.AdminTagPendingResponse">
+        SELECT
+            t.id,
+            t.name,
+            t.slug,
+            t.description,
+            t.color,
+            t.created_at,
+            t.created_by,
+            u.username AS created_by_username
+        FROM tags t
+        LEFT JOIN "user" u ON t.created_by = u.id
+        WHERE t.approval_status = 'PENDING'
+        ORDER BY t.created_at DESC
+    </select>
 </mapper>


### PR DESCRIPTION
### **描述 (Description)**

本次 Pull Request 的主要目标：

- 为博客系统新增完善的标签（Tag）功能：查询、详情、管理与审批相关接口与实现。
- 提供与标签相关的 DTO、Mapper、Service、Controller，新增分页查询工具以复用分页逻辑。

此改动涉及的模块：

- backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag
- backend/blog-backend/src/main/resources/mapper/content/tag
- backend/blog-backend/src/main/java/com/kisesaki/blog/common/util
- backend/blog-backend/src/main/resources/db/migration
- backend/blog-backend/src/main/resources/mapper/content/post（部分 PostsMapper 修改）

---

### **主要变更 (Changes)**

- **新增**: 多个标签模块相关类与文件
  - `TagController`, `AdminTagController`（Controller）
  - `TagService`, `AdminTagService`, `TagCommandService`, `TagQueryService`（Service 层）
  - DTO：`TagCreateRequest`, `TagListResponse`, `TagDetailResponse`, `PopularTagResponse`, `MyTagResponse`, 以及一系列 `AdminTag*` 请求/响应类
  - 实体/Mapper：`Tags.java`, `TagsMapper.xml`, `TagsMapper.java`
  - `TagUtils` 辅助工具
  - 数据库迁移脚本：`V7__update_tags_table_add_approval_fields.sql`
  - 新增分页工具类：`PageQueryUtils.java`

- **修改**:
  - `SlugUtils.java`（小范围调整）
  - `PostsMapper.xml`（修改部分查询/映射以兼容标签变更）
  - 若干 Tag 查询参数 DTO（`TagSearchParams` 等）调整

- **删除**:
  - 移除旧的 `PostQueryService`（已由新的查询工具或服务替代）
  - 删除旧的 `TagController.java`（被重构为新的控制器结构）

- **优化/重构**:
  - 将分页查询逻辑抽取到 `PageQueryUtils` 以减少重复代码并统一总数计算逻辑
  - 调整部分 DTO 的位置以更清晰地分离查询/命令模型

---

### **影响范围 (Impact)**

- 影响的功能/模块：标签相关的所有 API（公开查询接口、后台管理接口）、标签与文章的关联查询
- 是否涉及数据库/接口/配置变更：是 — 增加了数据库迁移脚本 `V7__update_tags_table_add_approval_fields.sql`，变更了 tags 表结构（新增审批相关字段），请在部署前执行相应的 Flyway/Liquibase 迁移
- 是否存在向下兼容性风险：有 — tags 表结构改变和部分 Controller/Service 的重命名/删除可能影响现有客户端或第三方集成。建议：
  - 发布时通知可能依赖旧接口的消费者
  - 在生产环境先在灰度环境或 staging 上执行数据库迁移并验证查询兼容性