### PR TITLE
🦄 refactor(permission+auth): 增强权限体系与控制，更新控制器权限注解

### DIFF
--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/AuthController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.kisesaki.blog.auth.controller;
 import java.util.Set;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,7 +13,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kisesaki.blog.auth.dto.auth.request.*;
+import com.kisesaki.blog.auth.dto.auth.request.ChangePasswordRequestDto;
+import com.kisesaki.blog.auth.dto.auth.request.ForgotPasswordRequestDto;
+import com.kisesaki.blog.auth.dto.auth.request.LoginRequestDto;
+import com.kisesaki.blog.auth.dto.auth.request.LogoutRequestDto;
+import com.kisesaki.blog.auth.dto.auth.request.RefreshTokenRequestDto;
+import com.kisesaki.blog.auth.dto.auth.request.RegisterRequestDto;
+import com.kisesaki.blog.auth.dto.auth.request.ResetPasswordRequestDto;
+import com.kisesaki.blog.auth.dto.auth.request.VerifyEmailRequestDto;
 import com.kisesaki.blog.auth.dto.auth.response.LoginResponseDto;
 import com.kisesaki.blog.auth.service.AuthService;
 import com.kisesaki.blog.common.dto.ApiResponse;
@@ -54,7 +62,8 @@ public class AuthController {
 
     @PostMapping("/verify-email")
     @Operation(summary = "验证邮箱", description = "使用邮箱验证令牌验证用户的邮箱")
-    public ResponseEntity<ApiResponse<String>> verifyEmail(@Valid @RequestBody VerifyEmailRequestDto verifyEmailRequest) {
+    public ResponseEntity<ApiResponse<String>> verifyEmail(
+            @Valid @RequestBody VerifyEmailRequestDto verifyEmailRequest) {
         ApiResponse<String> response = authService.verifyEmail(verifyEmailRequest);
         return ResponseEntity.ok(response);
     }
@@ -69,6 +78,7 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "用户登出", description = "用户登出当前设备")
     public ResponseEntity<ApiResponse<String>> logout(
             @Valid @RequestBody LogoutRequestDto logoutRequest,
@@ -81,6 +91,7 @@ public class AuthController {
     }
 
     @PostMapping("/logout-all")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "登出所有设备", description = "用户登出所有已登录的设备")
     public ResponseEntity<ApiResponse<String>> logoutAllDevices(Authentication authentication) {
         String username = authentication.getName();
@@ -89,6 +100,7 @@ public class AuthController {
     }
 
     @DeleteMapping("/devices/{deviceId}")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "踢出指定设备", description = "管理员或用户踢出指定设备")
     public ResponseEntity<ApiResponse<String>> kickDevice(
             @PathVariable String deviceId,
@@ -100,6 +112,7 @@ public class AuthController {
     }
 
     @GetMapping("/devices")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "获取用户设备列表", description = "获取当前用户所有已登录的设备")
     public ResponseEntity<ApiResponse<Set<String>>> getUserDevices(Authentication authentication) {
         String username = authentication.getName();
@@ -108,6 +121,7 @@ public class AuthController {
     }
 
     @PostMapping("change-password")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "修改密码", description = "用户修改自己的登录密码")
     public ResponseEntity<ApiResponse<String>> changePassword(
             @Valid @RequestBody ChangePasswordRequestDto changePasswordRequest,
@@ -135,6 +149,7 @@ public class AuthController {
     }
 
     @PostMapping("/clean-expired")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "清理过期令牌", description = "清理用户的过期令牌")
     public ResponseEntity<ApiResponse<String>> cleanExpiredTokens(
             Authentication authentication,

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "权限", description = "权限相关接口")
+@PreAuthorize("hasRole('ADMIN')")
 public class PermissionController {
 
     private final PermissionService permissionService;
@@ -41,7 +42,6 @@ public class PermissionController {
      * 获取权限列表
      */
     @GetMapping("")
-    @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<PageResponse<PermissionListResponse>> getPermissionsList(
             @Valid @RequestParam PermissionListParams params) {
         PageResponse<PermissionListResponse> pageResponse = permissionService.getPermissionsList(params);
@@ -52,7 +52,6 @@ public class PermissionController {
      * 根据ID获取权限详情
      */
     @GetMapping("/{id}")
-    @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<PermissionDetailResponse> getPermissionById(@PathVariable Long id) {
         // 这里调用service层的方法获取权限详情
         PermissionDetailResponse detailResponse = permissionService.getPermissionById(id);
@@ -63,7 +62,6 @@ public class PermissionController {
      * 创建权限
      */
     @PostMapping("")
-    @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<Void> createPermission(@Valid @RequestBody PermissionCreateRequest request) {
         permissionService.createPermission(request);
         return ApiResponse.success("权限创建成功");
@@ -73,7 +71,6 @@ public class PermissionController {
      * 更新权限
      */
     @PutMapping("/{id}")
-    @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<Void> updatePermission(@PathVariable Long id,
             @Valid @RequestBody PermissionUpdateRequest request) {
         permissionService.updatePermission(id, request);
@@ -84,7 +81,6 @@ public class PermissionController {
      * 删除权限
      */
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<Void> deletePermission(@PathVariable Long id) {
         permissionService.deletePermission(id);
         return ApiResponse.success("权限删除成功");

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/RoleController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/RoleController.java
@@ -33,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/admin/roles")
 @RequiredArgsConstructor
 @Tag(name = "角色管理", description = "角色的创建、删除、分配等操作")
+@PreAuthorize("hasRole('ADMIN')")
 public class RoleController {
 
     private final RoleService roleService;
@@ -41,7 +42,6 @@ public class RoleController {
      * 获取角色列表
      */
     @GetMapping("")
-    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "获取角色列表", description = "支持分页和按名称模糊搜索")
     public ApiResponse<PageResponse<RoleListResponse>> getRoleList(
             @Valid RoleListParams params) {
@@ -52,7 +52,6 @@ public class RoleController {
      * 获取角色详情（包含权限列表）
      */
     @GetMapping("/{id}")
-    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "获取角色详情", description = "获取角色详细信息，包含权限列表")
     public ApiResponse<RoleDetailResponse> getRoleDetail(@PathVariable Long id) {
         return ApiResponse.success(roleService.getRoleDetail(id));
@@ -62,7 +61,6 @@ public class RoleController {
      * 创建新角色
      */
     @PostMapping("")
-    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "创建角色", description = "创建新角色并分配权限")
     public ApiResponse<RoleDetailResponse> createRole(@Valid @RequestBody RoleCreateRequest request) {
         return ApiResponse.success(roleService.createRole(request));
@@ -72,7 +70,6 @@ public class RoleController {
      * 更新角色信息
      */
     @PutMapping("/{id}")
-    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "更新角色", description = "更新角色基本信息和权限")
     public ApiResponse<RoleDetailResponse> updateRole(@PathVariable Long id,
             @Valid @RequestBody RoleUpdateRequest request) {
@@ -83,7 +80,6 @@ public class RoleController {
      * 删除角色
      */
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "删除角色", description = "删除指定角色")
     public ApiResponse<Void> deleteRole(@PathVariable Long id) {
         roleService.deleteRole(id);
@@ -94,7 +90,6 @@ public class RoleController {
      * 获取角色权限列表
      */
     @GetMapping("/{id}/permissions")
-    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "获取角色权限", description = "获取指定角色的权限列表")
     public ApiResponse<List<RoleDetailResponse.PermissionDto>> getRolePermissions(@PathVariable Long id) {
         return ApiResponse.success(roleService.getRolePermissions(id));
@@ -104,7 +99,6 @@ public class RoleController {
      * 更新角色权限
      */
     @PutMapping("/{id}/permissions")
-    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "更新角色权限", description = "更新指定角色的权限配置")
     public ApiResponse<Void> updateRolePermissions(@PathVariable Long id,
             @Valid @RequestBody RolePermissionUpdateRequest request) {
@@ -116,7 +110,6 @@ public class RoleController {
      * 获取拥有该角色的用户列表
      */
     @GetMapping("/{id}/users")
-    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "获取角色用户", description = "获取拥有指定角色的用户列表")
     public ApiResponse<PageResponse<RoleUserListResponse>> getRoleUsers(@PathVariable Long id,
             @Valid RoleUserListParams params) {

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/common/enums/PermissionEnum.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/common/enums/PermissionEnum.java
@@ -10,20 +10,32 @@ public enum PermissionEnum {
     // ========== 文章管理权限 ==========
     /** 创建文章 */
     POST_CREATE("POST_CREATE", "创建文章", "post", "create"),
-    /** 更新文章 */
-    POST_UPDATE("POST_UPDATE", "更新文章", "post", "update"),
-    /** 删除文章 */
-    POST_DELETE("POST_DELETE", "删除文章", "post", "delete"),
+    /** 编辑自己的文章 */
+    POST_EDIT_OWN("POST_EDIT_OWN", "编辑自己的文章", "post", "edit_own"),
+    /** 编辑所有文章 */
+    POST_EDIT_ALL("POST_EDIT_ALL", "编辑所有文章", "post", "edit_all"),
+    /** 删除自己的文章 */
+    POST_DELETE_OWN("POST_DELETE_OWN", "删除自己的文章", "post", "delete_own"),
+    /** 删除所有文章 */
+    POST_DELETE_ALL("POST_DELETE_ALL", "删除所有文章", "post", "delete_all"),
     /** 发布文章 */
     POST_PUBLISH("POST_PUBLISH", "发布文章", "post", "publish"),
-    /** 查看所有文章 */
-    POST_VIEW_ALL("POST_VIEW_ALL", "查看所有文章", "post", "view_all"),
+    /** 管理文章 */
+    POST_MANAGE("POST_MANAGE", "管理文章", "post", "manage"),
+    /** 查看文章版本 */
+    POST_REVISION_VIEW("POST_REVISION_VIEW", "查看文章版本", "post", "revision_view"),
+    /** 恢复文章版本 */
+    POST_REVISION_RESTORE("POST_REVISION_RESTORE", "恢复文章版本", "post", "revision_restore"),
 
     // ========== 评论管理权限 ==========
     /** 创建评论 */
     COMMENT_CREATE("COMMENT_CREATE", "创建评论", "comment", "create"),
-    /** 删除评论 */
-    COMMENT_DELETE("COMMENT_DELETE", "删除评论", "comment", "delete"),
+    /** 编辑自己的评论 */
+    COMMENT_EDIT_OWN("COMMENT_EDIT_OWN", "编辑自己的评论", "comment", "edit_own"),
+    /** 删除自己的评论 */
+    COMMENT_DELETE_OWN("COMMENT_DELETE_OWN", "删除自己的评论", "comment", "delete_own"),
+    /** 删除所有评论 */
+    COMMENT_DELETE_ALL("COMMENT_DELETE_ALL", "删除所有评论", "comment", "delete_all"),
     /** 评论审核 */
     COMMENT_MODERATE("COMMENT_MODERATE", "评论审核", "comment", "moderate"),
 
@@ -34,36 +46,92 @@ public enum PermissionEnum {
     USER_VIEW_ALL("USER_VIEW_ALL", "查看用户列表", "user", "view_all"),
     /** 禁用用户 */
     USER_BAN("USER_BAN", "禁用用户", "user", "ban"),
+    /** 解禁用户 */
+    USER_UNBAN("USER_UNBAN", "解禁用户", "user", "unban"),
+    /** 编辑用户信息 */
+    USER_EDIT("USER_EDIT", "编辑用户信息", "user", "edit"),
+    /** 删除用户 */
+    USER_DELETE("USER_DELETE", "删除用户", "user", "delete"),
 
     // ========== 分类管理权限 ==========
+    /** 查看分类 */
+    CATEGORY_VIEW("CATEGORY_VIEW", "查看分类", "category", "view"),
     /** 创建分类 */
     CATEGORY_CREATE("CATEGORY_CREATE", "创建分类", "category", "create"),
-    /** 更新分类 */
-    CATEGORY_UPDATE("CATEGORY_UPDATE", "更新分类", "category", "update"),
+    /** 编辑分类 */
+    CATEGORY_EDIT("CATEGORY_EDIT", "编辑分类", "category", "edit"),
     /** 删除分类 */
     CATEGORY_DELETE("CATEGORY_DELETE", "删除分类", "category", "delete"),
 
     // ========== 标签管理权限 ==========
     /** 创建标签 */
     TAG_CREATE("TAG_CREATE", "创建标签", "tag", "create"),
-    /** 更新标签 */
-    TAG_UPDATE("TAG_UPDATE", "更新标签", "tag", "update"),
+    /** 编辑标签 */
+    TAG_EDIT("TAG_EDIT", "编辑标签", "tag", "edit"),
     /** 删除标签 */
     TAG_DELETE("TAG_DELETE", "删除标签", "tag", "delete"),
+    /** 管理标签 */
+    TAG_MANAGE("TAG_MANAGE", "管理标签", "tag", "manage"),
 
-    // ========== 媒体管理权限 ==========
-    /** 上传媒体文件 */
-    MEDIA_UPLOAD("MEDIA_UPLOAD", "上传媒体文件", "media", "upload"),
-    /** 删除媒体文件 */
-    MEDIA_DELETE("MEDIA_DELETE", "删除媒体文件", "media", "delete"),
-    /** 查看所有媒体文件 */
-    MEDIA_VIEW_ALL("MEDIA_VIEW_ALL", "查看所有媒体文件", "media", "view_all"),
+    // ========== 文件管理权限 ==========
+    /** 上传文件 */
+    FILE_UPLOAD("FILE_UPLOAD", "上传文件", "file", "upload"),
+    /** 删除自己的文件 */
+    FILE_DELETE_OWN("FILE_DELETE_OWN", "删除自己的文件", "file", "delete_own"),
+    /** 删除所有文件 */
+    FILE_DELETE_ALL("FILE_DELETE_ALL", "删除所有文件", "file", "delete_all"),
+    /** 查看所有文件 */
+    FILE_VIEW_ALL("FILE_VIEW_ALL", "查看所有文件", "file", "view_all"),
+
+    // ========== 通知管理权限 ==========
+    /** 发送通知 */
+    NOTIFICATION_SEND("NOTIFICATION_SEND", "发送通知", "notification", "send"),
+    /** 管理通知 */
+    NOTIFICATION_MANAGE("NOTIFICATION_MANAGE", "管理通知", "notification", "manage"),
+
+    // ========== 订阅管理权限 ==========
+    /** 管理订阅 */
+    SUBSCRIPTION_MANAGE("SUBSCRIPTION_MANAGE", "管理订阅", "subscription", "manage"),
+    /** 发送新闻通讯 */
+    NEWSLETTER_SEND("NEWSLETTER_SEND", "发送新闻通讯", "newsletter", "send"),
 
     // ========== 系统管理权限 ==========
-    /** 系统统计查看 */
-    SYSTEM_STATS_VIEW("SYSTEM_STATS_VIEW", "系统统计查看", "system", "stats_view"),
-    /** 系统配置管理 */
-    SYSTEM_CONFIG_MANAGE("SYSTEM_CONFIG_MANAGE", "系统配置管理", "system", "config_manage"),
+    /** 查看系统统计 */
+    SYSTEM_STATS_VIEW("SYSTEM_STATS_VIEW", "查看系统统计", "system", "stats_view"),
+    /** 管理系统配置 */
+    SYSTEM_CONFIG_MANAGE("SYSTEM_CONFIG_MANAGE", "管理系统配置", "system", "config_manage"),
+    /** 系统监控 */
+    SYSTEM_MONITOR("SYSTEM_MONITOR", "系统监控", "system", "monitor"),
+    /** 数据备份 */
+    SYSTEM_BACKUP("SYSTEM_BACKUP", "数据备份", "system", "backup"),
+    /** 数据恢复 */
+    SYSTEM_RESTORE("SYSTEM_RESTORE", "数据恢复", "system", "restore"),
+
+    // ========== SEO管理权限 ==========
+    /** 管理SEO设置 */
+    SEO_MANAGE("SEO_MANAGE", "管理SEO设置", "seo", "manage"),
+
+    // ========== 重定向管理权限 ==========
+    /** 管理重定向 */
+    REDIRECT_MANAGE("REDIRECT_MANAGE", "管理重定向", "redirect", "manage"),
+
+    // ========== 举报管理权限 ==========
+    /** 处理举报 */
+    REPORT_HANDLE("REPORT_HANDLE", "处理举报", "report", "handle"),
+    /** 查看举报 */
+    REPORT_VIEW("REPORT_VIEW", "查看举报", "report", "view"),
+
+    // ========== 审计权限 ==========
+    /** 查看审计日志 */
+    AUDIT_VIEW("AUDIT_VIEW", "查看审计日志", "audit", "view"),
+    /** 导出数据 */
+    DATA_EXPORT("DATA_EXPORT", "导出数据", "data", "export"),
+
+    // ========== 分析权限 ==========
+    /** 查看分析数据 */
+    ANALYTICS_VIEW("ANALYTICS_VIEW", "查看分析数据", "analytics", "view"),
+    /** 管理分析配置 */
+    ANALYTICS_MANAGE("ANALYTICS_MANAGE", "管理分析配置", "analytics", "manage"),
 
     // ========== 仪表板权限 ==========
     /** 管理员仪表板访问 */

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/config/SecurityConfig.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/config/SecurityConfig.java
@@ -39,6 +39,17 @@ import lombok.extern.slf4j.Slf4j;
  * - 无状态会话管理
  * - 自定义认证过滤器
  * - 统一异常处理
+ * <p>
+ * 角色层级定义：
+ * - ADMIN：管理员，拥有所有权限，可以管理系统配置、用户、审计等
+ * - EDITOR：编辑者，可以管理内容相关功能（文章、分类、标签、评论、媒体）
+ * - AUTHOR：作者，可以创建和管理自己的文章、标签
+ * - USER：普通用户，可以评论、点赞、收藏等基础交互功能
+ * <p>
+ * 权限控制策略：
+ * - URL级别：基于角色的粗粒度控制
+ * - 方法级别：通过@PreAuthorize进行细粒度权限控制（如own vs all）
+ * - 业务级别：在Service层进行具体的业务逻辑权限验证
  */
 @Configuration
 @EnableWebSecurity
@@ -172,37 +183,48 @@ public class SecurityConfig {
                                                 .requestMatchers(HttpMethod.POST, "/posts/*/view")
                                                 .permitAll()
 
-                                                // 用户创作接口：需要登录
+                                                // 用户创作接口：需要创建文章权限
+                                                .requestMatchers(HttpMethod.POST, "/posts")
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR")
+
+                                                // 我的文章相关：需要登录
                                                 .requestMatchers(
                                                                 "/posts/my/**",
-                                                                "/posts/*/preview",
+                                                                "/posts/*/preview")
+                                                .authenticated()
+
+                                                // 文章编辑：需要编辑权限（具体权限在Service层判断own vs all）
+                                                .requestMatchers(HttpMethod.PUT, "/posts/*")
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR")
+
+                                                // 文章发布：需要发布权限
+                                                .requestMatchers(HttpMethod.PUT, "/posts/*/publish")
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR")
+
+                                                .requestMatchers(HttpMethod.PUT, "/posts/*/unpublish")
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR")
+
+                                                // 文章删除：需要删除权限
+                                                .requestMatchers(HttpMethod.DELETE, "/posts/*")
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR")
+
+                                                // 文章复制：需要创建权限
+                                                .requestMatchers(HttpMethod.POST, "/posts/*/duplicate")
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR")
+
+                                                // 文章元数据管理：需要编辑权限
+                                                .requestMatchers(
                                                                 "/posts/*/meta",
                                                                 "/posts/*/meta/*")
-                                                .authenticated()
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR")
 
-                                                .requestMatchers(HttpMethod.POST, "/posts")
-                                                .authenticated()
+                                                // 文章版本管理：需要版本查看权限
+                                                .requestMatchers(HttpMethod.GET, "/posts/*/revisions/**")
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR")
 
-                                                .requestMatchers(HttpMethod.PUT,
-                                                                "/posts/*",
-                                                                "/posts/*/publish",
-                                                                "/posts/*/unpublish",
-                                                                "/posts/*/meta")
-                                                .authenticated()
-
-                                                .requestMatchers(HttpMethod.DELETE,
-                                                                "/posts/*",
-                                                                "/posts/*/meta/*")
-                                                .authenticated()
-
-                                                .requestMatchers(HttpMethod.POST, "/posts/*/duplicate")
-                                                .authenticated()
-
-                                                // 文章版本管理：需要登录
-                                                .requestMatchers("/posts/*/revisions/**")
-                                                .authenticated()
-
-                                                // 文章交互：点赞需要登录
+                                                // 文章版本恢复：需要版本恢复权限
+                                                .requestMatchers(HttpMethod.POST, "/posts/*/revisions/*/restore")
+                                                .hasAnyRole("ADMIN", "EDITOR") // 文章交互：点赞需要登录
                                                 .requestMatchers(
                                                                 "/posts/*/like")
                                                 .authenticated()
@@ -229,14 +251,12 @@ public class SecurityConfig {
                                                 .requestMatchers(HttpMethod.GET, "/tags/search")
                                                 .authenticated()
 
-                                                // 用户创建标签：需要登录
+                                                // 用户创建标签：需要标签创建权限
                                                 .requestMatchers(HttpMethod.POST, "/tags")
-                                                .authenticated()
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR")
 
                                                 .requestMatchers("/tags/my")
-                                                .authenticated()
-
-                                                // ==================== 用户系统接口 ====================
+                                                .authenticated() // ==================== 用户系统接口 ====================
                                                 // 用户公开信息
                                                 .requestMatchers(HttpMethod.GET,
                                                                 "/users/*",
@@ -282,22 +302,26 @@ public class SecurityConfig {
                                                                 "/comments/*/report")
                                                 .authenticated()
 
+                                                // 评论创建：需要评论创建权限
+                                                .requestMatchers(HttpMethod.POST, "/posts/*/comments")
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR", "USER")
+
+                                                // 评论点赞：需要登录
                                                 .requestMatchers(HttpMethod.POST,
-                                                                "/posts/*/comments",
                                                                 "/comments/*/like",
                                                                 "/comments/*/dislike")
                                                 .authenticated()
 
+                                                // 评论编辑：需要登录（具体权限在Service层判断）
                                                 .requestMatchers(HttpMethod.PUT, "/comments/*")
                                                 .authenticated()
 
+                                                // 评论删除：需要登录（具体权限在Service层判断）
                                                 .requestMatchers(HttpMethod.DELETE,
                                                                 "/comments/*",
                                                                 "/comments/*/like",
                                                                 "/comments/*/dislike")
-                                                .authenticated()
-
-                                                // ==================== 点赞收藏关注接口 ====================
+                                                .authenticated() // ==================== 点赞收藏关注接口 ====================
                                                 // 公开查看点赞收藏
                                                 .requestMatchers(HttpMethod.GET,
                                                                 "/posts/*/likes",
@@ -315,11 +339,17 @@ public class SecurityConfig {
                                                 .authenticated()
 
                                                 // ==================== 媒体资源接口 ====================
-                                                // 文件上传：需要登录
-                                                .requestMatchers("/media/**")
-                                                .authenticated()
+                                                // 文件上传：需要上传权限
+                                                .requestMatchers(HttpMethod.POST, "/media/**")
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR")
 
-                                                // ==================== 搜索和统计接口 ====================
+                                                // 文件管理：需要文件管理权限
+                                                .requestMatchers(HttpMethod.DELETE, "/media/**")
+                                                .hasAnyRole("ADMIN", "EDITOR", "AUTHOR")
+
+                                                // 查看文件：需要登录
+                                                .requestMatchers(HttpMethod.GET, "/media/**")
+                                                .authenticated() // ==================== 搜索和统计接口 ====================
                                                 // 搜索：公开
                                                 .requestMatchers("/search/**")
                                                 .permitAll()
@@ -368,11 +398,42 @@ public class SecurityConfig {
                                                 .authenticated()
 
                                                 // ==================== 管理员接口 ====================
-                                                // 所有管理员接口：需要管理员权限
-                                                .requestMatchers("/admin/**")
+                                                // 文章管理接口：需要文章管理权限
+                                                .requestMatchers("/admin/posts/**")
+                                                .hasAnyRole("ADMIN", "EDITOR")
+
+                                                // 分类管理接口：需要分类管理权限
+                                                .requestMatchers("/admin/categories/**")
+                                                .hasAnyRole("ADMIN", "EDITOR")
+
+                                                // 标签管理接口：需要标签管理权限
+                                                .requestMatchers("/admin/tags/**")
+                                                .hasAnyRole("ADMIN", "EDITOR")
+
+                                                // 用户管理接口：需要管理员权限
+                                                .requestMatchers("/admin/users/**")
                                                 .hasRole("ADMIN")
 
-                                                // ==================== 其他接口 ====================
+                                                // 评论管理接口：需要评论管理权限
+                                                .requestMatchers("/admin/comments/**")
+                                                .hasAnyRole("ADMIN", "EDITOR")
+
+                                                // 媒体管理接口：需要文件管理权限
+                                                .requestMatchers("/admin/media/**")
+                                                .hasAnyRole("ADMIN", "EDITOR")
+
+                                                // 系统管理接口：需要管理员权限
+                                                .requestMatchers(
+                                                                "/admin/system/**",
+                                                                "/admin/settings/**",
+                                                                "/admin/analytics/**",
+                                                                "/admin/reports/**",
+                                                                "/admin/audit/**")
+                                                .hasRole("ADMIN")
+
+                                                // 其他管理员接口：需要管理员权限
+                                                .requestMatchers("/admin/**")
+                                                .hasRole("ADMIN") // ==================== 其他接口 ====================
                                                 // 其他所有请求都需要认证
                                                 .anyRequest().authenticated())
 

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/AdminPostController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/AdminPostController.java
@@ -37,7 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "管理员文章管理", description = "管理员文章管理相关接口")
-@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("hasAuthority('POST_MANAGE')")
 public class AdminPostController {
 
     private final AdminPostService postAdminService;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/PostController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/PostController.java
@@ -142,7 +142,7 @@ public class PostController {
      * 更新文章
      */
     @PutMapping("/{id}")
-    @PreAuthorize("hasAuthority('POST_UPDATE')")
+    @PreAuthorize("hasAuthority('POST_EDIT_OWN') or hasAuthority('POST_EDIT_ALL')")
     public ApiResponse<UpdatePostResponse> updatePost(@PathVariable Long id,
             @Valid @RequestBody UpdatePostRequest request,
             Authentication authentication) {
@@ -156,7 +156,7 @@ public class PostController {
      * 删除文章
      */
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAuthority('POST_DELETE')")
+    @PreAuthorize("hasAuthority('POST_DELETE_OWN') or hasAuthority('POST_DELETE_ALL')")
     public ApiResponse<Void> deletePost(@PathVariable Long id, Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         log.info("用户 {} 删除文章 {}", userId, id);
@@ -208,6 +208,7 @@ public class PostController {
      * @return 文章列表
      */
     @GetMapping("/my")
+    @PreAuthorize("isAuthenticated()")
     public ApiResponse<PageResponse<MyPostsListResponse>> getMyPosts(
             @Valid GetMyPostsListParams params,
             Authentication authentication) {
@@ -233,6 +234,7 @@ public class PostController {
      * @return 文章元数据
      */
     @GetMapping("/{id}/meta")
+    @PreAuthorize("hasAuthority('POST_EDIT_OWN') or hasAuthority('POST_EDIT_ALL')")
     public ApiResponse<MetaDataDto.PostMetaResponse> getPostMeta(@PathVariable Long id,
             Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
@@ -249,6 +251,7 @@ public class PostController {
      * @return 更新后的元数据
      */
     @PutMapping("/{id}/meta")
+    @PreAuthorize("hasAuthority('POST_EDIT_OWN') or hasAuthority('POST_EDIT_ALL')")
     public ApiResponse<MetaDataDto.PostMetaResponse> updatePostMeta(@PathVariable Long id,
             @Valid @RequestBody MetaDataDto.UpdatePostMetaRequest request,
             Authentication authentication) {
@@ -267,6 +270,7 @@ public class PostController {
      * @return 删除结果
      */
     @DeleteMapping("/{id}/meta/{key}")
+    @PreAuthorize("hasAuthority('POST_EDIT_OWN') or hasAuthority('POST_EDIT_ALL')")
     public ApiResponse<Void> deletePostMeta(@PathVariable Long id, @PathVariable String key,
             Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
@@ -288,6 +292,7 @@ public class PostController {
      * @return 文章版本列表
      */
     @GetMapping("/{postId}/revisions")
+    @PreAuthorize("hasAuthority('POST_REVISION_VIEW')")
     public ApiResponse<PageResponse<RevisionInfo>> getPostRevisions(@PathVariable Long postId,
             @Valid PostRevisionListParams params,
             Authentication authentication) {
@@ -310,6 +315,7 @@ public class PostController {
      * @return 文章版本内容
      */
     @GetMapping("/{postId}/revisions/{revisionId}")
+    @PreAuthorize("hasAuthority('POST_REVISION_VIEW')")
     public ApiResponse<PostRevisionContentResponse> getPostRevisionContent(@PathVariable Long postId,
             @PathVariable Long revisionId,
             Authentication authentication) {
@@ -331,6 +337,7 @@ public class PostController {
      * @return 操作结果
      */
     @PostMapping("/{postId}/revisions/{revisionId}/restore")
+    @PreAuthorize("hasAuthority('POST_REVISION_RESTORE')")
     public ApiResponse<Void> restorePostRevision(@PathVariable Long postId, @PathVariable Long revisionId,
             Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
@@ -343,6 +350,7 @@ public class PostController {
     }
 
     @DeleteMapping("/{postId}/revisions/{revisionId}")
+    @PreAuthorize("hasAuthority('POST_EDIT_OWN') or hasAuthority('POST_EDIT_ALL')")
     public ApiResponse<Void> deletePostRevision(@PathVariable Long postId, @PathVariable Long revisionId,
             Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/tag/controller/AdminTagController.java
@@ -2,6 +2,7 @@ package com.kisesaki.blog.content.tag.controller;
 
 import java.util.List;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,6 +44,7 @@ public class AdminTagController {
      * 获取管理员标签列表
      */
     @GetMapping("")
+    @PreAuthorize("hasAuthority('TAG_MANAGE')")
     public ApiResponse<PageResponse<AdminTagListResponse>> adminGetTagList(@Valid AdminTagListParams params) {
         return ApiResponse.success(adminTagService.adminGetTagList(params));
     }
@@ -51,6 +53,7 @@ public class AdminTagController {
      * 创建新标签
      */
     @PostMapping("")
+    @PreAuthorize("hasAuthority('TAG_CREATE')")
     public ApiResponse<Long> adminTagCreate(@Valid @RequestBody AdminTagCreateRequest request,
             Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
@@ -61,6 +64,7 @@ public class AdminTagController {
      * 更新标签
      */
     @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('TAG_EDIT')")
     public ApiResponse<Void> adminTagUpdate(@PathVariable("id") Long id,
             @Valid @RequestBody AdminTagUpdateRequest request,
             Authentication authentication) {
@@ -73,6 +77,7 @@ public class AdminTagController {
      * 删除标签
      */
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('TAG_DELETE')")
     public ApiResponse<Void> adminTagDelete(@PathVariable("id") Long id, Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         adminTagService.adminTagDelete(id, userId);
@@ -83,6 +88,7 @@ public class AdminTagController {
      * 审核标签
      */
     @PutMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('TAG_MANAGE')")
     public ApiResponse<Void> adminTagApprove(@PathVariable("id") Long id,
             @Valid @RequestBody AdminTagApprovalRequest request,
             Authentication authentication) {
@@ -95,6 +101,7 @@ public class AdminTagController {
      * 获取所有待审核标签
      */
     @GetMapping("/pending")
+    @PreAuthorize("hasAuthority('TAG_MANAGE')")
     public ApiResponse<List<AdminTagPendingResponse>> adminGetPendingTags() {
         return ApiResponse.success(adminTagService.adminGetPendingTags());
     }
@@ -103,6 +110,7 @@ public class AdminTagController {
      * 获取未使用的标签列表
      */
     @GetMapping("/unused")
+    @PreAuthorize("hasAuthority('TAG_MANAGE')")
     public ApiResponse<List<AdminTagUnusedResponse>> adminGetUnusedTags(
             @RequestParam(value = "unusedDays", required = false) Integer unusedDays) {
         return ApiResponse.success(adminTagService.adminGetUnusedTags(unusedDays));
@@ -112,6 +120,7 @@ public class AdminTagController {
      * 清理未使用的标签
      */
     @DeleteMapping("/cleanup")
+    @PreAuthorize("hasAuthority('TAG_DELETE')")
     public ApiResponse<AdminTagCleanupResponse> adminCleanupUnusedTags(
             @RequestParam(value = "unusedDays", required = false, defaultValue = "30") Integer unusedDays,
             Authentication authentication) {
@@ -123,6 +132,7 @@ public class AdminTagController {
      * 合并标签
      */
     @PostMapping("/merge")
+    @PreAuthorize("hasAuthority('TAG_MANAGE')")
     public ApiResponse<Void> adminMergeTags(@Valid @RequestBody AdminTagMergeRequest request,
             Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/file/FileController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/file/FileController.java
@@ -22,7 +22,7 @@ class FileController {
     private final FileUploadService fileUploadService;
 
     @PostMapping("/upload")
-    @PreAuthorize("hasAuthority('MEDIA_UPLOAD')")
+    @PreAuthorize("hasAuthority('FILE_UPLOAD')")
     public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file, Authentication authentication) {
         if (file.isEmpty()) {
             return ResponseEntity.badRequest().body("上传的文件不能为空");

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/user/UserController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/user/UserController.java
@@ -49,6 +49,7 @@ public class UserController {
     private final UserFollowService userFollowService;
 
     @PostMapping("/getUserInfoByToken")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "根据token获取当前用户信息", description = "获取当前登录用户的详细信息")
     public ResponseEntity<ApiResponse<UserInfoDto>> getUserInfoByToken(Authentication authentication) {
         String username = AuthUtils.getUsernameFromAuthentication(authentication);
@@ -81,6 +82,7 @@ public class UserController {
     }
 
     @PutMapping("/profile")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "更新用户资料", description = "更新当前用户的个人资料")
     public ResponseEntity<ApiResponse<UserInfoDto>> updateProfile(
             Authentication authentication,
@@ -91,6 +93,7 @@ public class UserController {
     }
 
     @PostMapping("/avatar")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "更新用户头像", description = "更新当前用户的头像")
     public ResponseEntity<ApiResponse<UserInfoDto>> updateAvatar(
             Authentication authentication,
@@ -101,7 +104,7 @@ public class UserController {
     }
 
     @PostMapping("/upload-avatar")
-    @PreAuthorize("hasAuthority('MEDIA_UPLOAD')")
+    @PreAuthorize("hasAuthority('FILE_UPLOAD')")
     @Operation(summary = "上传用户头像", description = "上传并更新当前用户的头像文件")
     public ResponseEntity<ApiResponse<UserInfoDto>> uploadAvatar(
             Authentication authentication,
@@ -129,6 +132,7 @@ public class UserController {
     }
 
     @GetMapping("/settings")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "获取用户设置", description = "获取当前用户的所有设置")
     public ResponseEntity<ApiResponse<Map<String, String>>> getUserSettings(Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
@@ -137,6 +141,7 @@ public class UserController {
     }
 
     @PutMapping("/settings")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "更新用户设置", description = "批量更新用户设置")
     public ResponseEntity<ApiResponse<String>> updateUserSettings(
             Authentication authentication,


### PR DESCRIPTION
### **描述 (Description)**

本次 Pull Request 的主要目标：

- 完善并扩展权限枚举与角色层级说明，增加细粒度权限定义。
- 在多个控制器中添加或更新权限注解，确保接口按角色/权限正确受限。

此改动涉及的模块：

- backend/blog-backend/src/main/java/com/kisesaki/blog/content/post (AdminPostController 等)
- backend/blog-backend/src/main/java/com/kisesaki/blog/auth (AuthController 等)
- backend/blog-backend/src/main/java/com/kisesaki/blog/permission (PermissionController, RoleController 等)

---

### **主要变更 (Changes)**

- **新增**: 无新增业务表结构；权限枚举中新增多项权限定义（具体项见提交详情）。
- **修改**: 更新并增加多个控制器的权限注解与接口权限要求（包含但不限于 AuthController、PermissionController、RoleController、AdminPostController、PostController、AdminTagController、FileController、UserController）。
- **删除**: 无删除。
- **优化/重构**: 完善权限控制策略与角色层级说明，调整权限枚举以支持更细粒度的访问控制。

---

### **影响范围 (Impact)**

- 影响权限校验逻辑和接口访问控制，涉及用户登录/登出、文章管理、标签管理、文件上传、角色与权限管理等功能。
- 仅涉及后端权限与注解变更；若前端基于权限显示/隐藏功能，需同步更新前端权限名称或枚举映射。
- 向下兼容性：变更主要是权限定义与注解加强，若已有角色不包含新权限，可能导致部分接口对旧角色变得不可访问，存在向下兼容风险，需在部署前同步更新角色/权限数据或在迁移说明中提示。

---

提交摘要（按时间逆序，供审阅）：

- 7610172 | akko | 2025-09-18
  - ✨ feat(auth): 增强权限控制，更新多个控制器的权限注解
  - 说明：为多个控制器添加了权限注解，确保只有具备相应权限的用户才能访问相关接口。具体包括：AuthController、PermissionController、RoleController、AdminPostController、PostController、AdminTagController、FileController、UserController。

- 5c6b571 | akko | 2025-09-18
  - ✨ feat(permission): 更新权限枚举，新增多项权限定义及角色层级说明
  - 说明：新增了文章、评论、分类、标签、文件、通知、订阅等管理权限，完善了角色层级定义和权限控制策略。
