### PR TITLE
✨feat(Auth): 添加忘记密码与重置密码功能及相关 UI 组件

### DIFF
--- a/frontend/src/components/common/FailedCard.tsx
+++ b/frontend/src/components/common/FailedCard.tsx
@@ -1,0 +1,39 @@
+import AuthLayout from './AuthLayout';
+
+interface FailedCardProps {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}
+
+/**
+ * 邮箱验证失败卡片
+ * @param title 标题
+ * @param description 描述
+ * @param children 卡片内容
+ * @returns 组件
+ */
+export const FailedCard = ({
+  title,
+  description,
+  children,
+}: FailedCardProps) => {
+  return (
+    <AuthLayout
+      title={title}
+      description={description}
+      footer={
+        <div className='w-full text-center space-y-2'>
+          <div className='text-sm'>
+            还没有账户？{' '}
+            <a href='/auth/register' className='text-primary hover:underline'>
+              立即注册
+            </a>
+          </div>
+        </div>
+      }
+    >
+      {children}
+    </AuthLayout>
+  );
+};

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,5 +1,6 @@
 import { Slot } from '@radix-ui/react-slot';
 import { type VariantProps } from 'class-variance-authority';
+import { Loader2 } from 'lucide-react';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -10,10 +11,12 @@ function Button({
   variant,
   size,
   asChild = false,
+  loading = false,
   ...props
 }: React.ComponentProps<'button'> &
   VariantProps<typeof ButtonVariants> & {
     asChild?: boolean;
+    loading?: boolean;
   }) {
   const Comp = asChild ? Slot : 'button';
 
@@ -21,8 +24,12 @@ function Button({
     <Comp
       data-slot='button'
       className={cn(ButtonVariants({ variant, size, className }))}
+      disabled={loading || props.disabled}
       {...props}
-    />
+    >
+      {loading && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+      {props.children}
+    </Comp>
   );
 }
 

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -8,6 +8,7 @@ export * from './useAuth';
 export * from './useAuthManager';
 export * from './useBlog';
 export * from './useLocalStorage';
+export * from './usePassword';
 export * from './usePermissions';
 export * from './useRegister';
 export * from './useResponsive';

--- a/frontend/src/hooks/usePassword.ts
+++ b/frontend/src/hooks/usePassword.ts
@@ -1,0 +1,90 @@
+import {
+  changePasswordApi,
+  forgotPasswordApi,
+  resetPasswordApi,
+} from '@/api/auth';
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * 密码相关操作 Hook
+ * - 使用统一的 perform 函数减少重复
+ * - 对外仍然暴露每个操作的独立 loading 状态，便于组件按需禁用/显示 spinner
+ */
+export const usePassword = () => {
+  type Key = 'forgot' | 'reset' | 'change';
+  const [loadingMap, setLoadingMap] = useState<Record<Key, boolean>>({
+    forgot: false,
+    reset: false,
+    change: false,
+  });
+
+  const setLoading = useCallback((key: Key, value: boolean) => {
+    setLoadingMap(s => ({ ...s, [key]: value }));
+  }, []);
+
+  /**
+   * 通用执行器：接收一个返回 Promise 的函数（延迟执行），并管理对应 key 的 loading 与错误处理
+   * successMsg 可选用于成功提示
+   */
+  const perform = useCallback(
+    async (
+      key: Key,
+      fn: () => Promise<unknown>,
+      successMsg?: string
+    ): Promise<boolean> => {
+      try {
+        setLoading(key, true);
+        await fn();
+        if (successMsg) toast.success(successMsg);
+        return true;
+      } catch (error) {
+        console.error(error);
+        return false;
+      } finally {
+        setLoading(key, false);
+      }
+    },
+    [setLoading]
+  );
+
+  const forgotPassword = useCallback(
+    async (email: string) =>
+      perform(
+        'forgot',
+        () => forgotPasswordApi({ email }),
+        '重置密码邮件发送成功，请检查您的邮箱。'
+      ),
+    [perform]
+  );
+
+  const resetPassword = useCallback(
+    async (resetToken: string, newPassword: string) =>
+      perform(
+        'reset',
+        () => resetPasswordApi({ resetToken, newPassword }),
+        '密码重置成功，请使用新密码登录。'
+      ),
+    [perform]
+  );
+
+  const changePassword = useCallback(
+    async (oldPassword: string, newPassword: string) =>
+      perform(
+        'change',
+        () => changePasswordApi({ oldPassword, newPassword }),
+        '密码更改成功，请使用新密码登录。'
+      ),
+    [perform]
+  );
+
+  return {
+    forgotLoading: loadingMap.forgot,
+    resetLoading: loadingMap.reset,
+    changeLoading: loadingMap.change,
+
+    forgotPassword,
+    resetPassword,
+    changePassword,
+  };
+};

--- a/frontend/src/pages/Auth/EmailVerificationPage.tsx
+++ b/frontend/src/pages/Auth/EmailVerificationPage.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components';
 import AuthLayout from '@/components/common/AuthLayout';
+import { FailedCard } from '@/components/common/FailedCard';
 import { useAuth, useRegister } from '@/hooks';
 import { AlertCircle, CheckCircle, Mail } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -102,7 +103,7 @@ const EmailVerificationPage = () => {
   // 如果验证失败，显示错误状态
   if (verificationFailed) {
     return (
-      <FailedCard>
+      <FailedCard title='邮箱验证' description='验证令牌无效或已过期'>
         <div className='text-center space-y-4'>
           <div className='flex justify-center'>
             <AlertCircle className='h-16 w-16 text-theme-success' />
@@ -136,7 +137,7 @@ const EmailVerificationPage = () => {
 
   // 如果没有token，显示提示信息
   return (
-    <FailedCard>
+    <FailedCard title='邮箱验证' description='验证令牌无效或已过期'>
       <div className='text-center space-y-4'>
         <div className='flex justify-center'>
           <Mail className='h-16 w-16 text-muted-foreground' />
@@ -157,28 +158,3 @@ const EmailVerificationPage = () => {
 };
 
 export default EmailVerificationPage;
-
-/**
- * 邮箱验证失败卡片
- * @param children 卡片内容
- */
-const FailedCard = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <AuthLayout
-      title='邮箱验证失败'
-      description='验证令牌无效或已过期'
-      footer={
-        <div className='w-full text-center space-y-2'>
-          <div className='text-sm'>
-            还没有账户？{' '}
-            <a href='/auth/register' className='text-primary hover:underline'>
-              立即注册
-            </a>
-          </div>
-        </div>
-      }
-    >
-      {children}
-    </AuthLayout>
-  );
-};

--- a/frontend/src/pages/Auth/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/Auth/ForgotPasswordPage.tsx
@@ -4,6 +4,7 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
   Input,
 } from '@/components';
 import AuthLayout from '@/components/common/AuthLayout';
@@ -27,7 +28,7 @@ const ForgotPasswordPage = () => {
     },
   });
 
-  const { forgotPassword } = usePassword();
+  const { forgotPassword, forgotLoading } = usePassword();
   // 提交表单
   const handleSubmit = async (data: { email: EmailFormData }) => {
     const success = await forgotPassword(data.email);
@@ -50,10 +51,11 @@ const ForgotPasswordPage = () => {
               <FormItem>
                 <FormLabel>邮箱地址</FormLabel>
                 <Input type='email' placeholder='请输入您的邮箱' {...field} />
+                <FormMessage />
               </FormItem>
             )}
           />
-          <Button type='submit' className='w-full'>
+          <Button loading={forgotLoading} type='submit' className='w-full'>
             发送重置密码邮件
           </Button>
         </form>

--- a/frontend/src/pages/Auth/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/Auth/ForgotPasswordPage.tsx
@@ -1,9 +1,65 @@
+import {
+  Button,
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  Input,
+} from '@/components';
+import AuthLayout from '@/components/common/AuthLayout';
+import { usePassword } from '@/hooks';
+import { emailSchema, type EmailFormData } from '@/shcema';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import z from 'zod';
+
 /**
  * 忘记密码页面
  * 用户请求重置密码的页面
  */
+
 const ForgotPasswordPage = () => {
-  return <div>ForgotPasswordPage</div>;
+  // 表单实例
+  const form = useForm<{ email: EmailFormData }>({
+    resolver: zodResolver(z.object({ email: emailSchema })),
+    defaultValues: {
+      email: '',
+    },
+  });
+
+  const { forgotPassword } = usePassword();
+  // 提交表单
+  const handleSubmit = async (data: { email: EmailFormData }) => {
+    const success = await forgotPassword(data.email);
+    if (success) {
+      form.reset();
+    }
+  };
+
+  return (
+    <AuthLayout
+      title='忘记密码'
+      description='请输入您的注册邮箱，我们会发送一封重置密码的邮件给您。'
+    >
+      <Form {...form}>
+        <form className='space-y-4' onSubmit={form.handleSubmit(handleSubmit)}>
+          <FormField
+            name='email'
+            control={form.control}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>邮箱地址</FormLabel>
+                <Input type='email' placeholder='请输入您的邮箱' {...field} />
+              </FormItem>
+            )}
+          />
+          <Button type='submit' className='w-full'>
+            发送重置密码邮件
+          </Button>
+        </form>
+      </Form>
+    </AuthLayout>
+  );
 };
 
 export default ForgotPasswordPage;

--- a/frontend/src/pages/Auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/Auth/ResetPasswordPage.tsx
@@ -1,9 +1,162 @@
+import {
+  Button,
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+} from '@/components';
+import AuthLayout from '@/components/common/AuthLayout';
+import { FailedCard } from '@/components/common/FailedCard';
+import { usePassword } from '@/hooks';
+import { passwordSchema, type PasswordField } from '@/shcema';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { CheckCircle, Mail } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+import { toast } from 'sonner';
+import z from 'zod';
+
 /**
  * 重置密码页面
  * 用户通过邮件链接重置密码的页面
  */
 const ResetPasswordPage = () => {
-  return <div>ResetPasswordPage</div>;
+  const { resetPassword, resetLoading } = usePassword();
+
+  // 验证状态
+  const [isVerified, setIsVerified] = useState(false);
+  // 是否验证失败
+  const [verificationFailed, setVerificationFailed] = useState(false);
+
+  const navigate = useNavigate();
+  // 获取token
+  const tokenFromUrl = new URL(window.location.href).searchParams.get('token');
+
+  // form 实例
+  const form = useForm<{ password: PasswordField }>({
+    resolver: zodResolver(z.object({ password: passwordSchema })),
+    defaultValues: {
+      password: '',
+    },
+  });
+
+  // 有 token 且未验证成功或失败
+  if (tokenFromUrl && !isVerified && !verificationFailed) {
+    // 提交表单
+    const handleSubmit = async (data: { password: PasswordField }) => {
+      const success = await resetPassword(tokenFromUrl, data.password);
+      if (success) {
+        setIsVerified(true);
+        toast.success('密码重置成功！请使用新密码登录。');
+
+        setTimeout(() => {
+          navigate('/auth/login');
+        }, 5000);
+      } else {
+        setVerificationFailed(true);
+        toast.error('密码重置失败，即将跳转重置页面。');
+
+        setTimeout(() => {
+          navigate('/auth/forgot-password');
+        }, 5000);
+      }
+    };
+
+    return (
+      <AuthLayout title='重置密码' description='请输入您的新密码以完成重置'>
+        <Form {...form}>
+          <form
+            className='space-y-4'
+            onSubmit={form.handleSubmit(handleSubmit)}
+          >
+            <FormField
+              name='password'
+              control={form.control}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>新密码</FormLabel>
+                  <Input {...field} type='password' placeholder='新密码' />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button loading={resetLoading} type='submit' className='w-full'>
+              重置密码
+            </Button>
+          </form>
+        </Form>
+      </AuthLayout>
+    );
+  }
+
+  // 如果已经验证成功，就显示成功状态并跳转
+  if (isVerified) {
+    return (
+      <AuthLayout
+        title='密码重置成功'
+        description='您的密码已成功重置，即将跳转到登录页面'
+      >
+        <div className='text-center space-y-4'>
+          <div className='flex justify-center'>
+            <CheckCircle className='h-16 w-16 text-theme-success' />
+          </div>
+          <p className='text-theme-success'>
+            密码重置成功！您的新密码已生效，可以正常登录使用。
+          </p>
+          <Button onClick={() => navigate('/auth/login')} className='w-full'>
+            前往登录
+          </Button>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  if (verificationFailed) {
+    return (
+      <AuthLayout
+        title='密码重置失败'
+        description='您的密码重置请求已失败，请重试'
+      >
+        <div className='text-center space-y-4'>
+          <div className='flex justify-center'>
+            <Mail className='h-16 w-16 text-theme-error' />
+          </div>
+          <p className='text-theme-error'>
+            密码重置失败！请检查您的链接是否有效。
+          </p>
+          <Button
+            onClick={() => navigate('/auth/forgot-password')}
+            className='w-full'
+          >
+            重新发送验证邮件
+          </Button>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <FailedCard title='重置密码' description=''>
+      <div className='text-center space-y-4'>
+        <div className='flex justify-center'>
+          <Mail className='h-16 w-16 text-muted-foreground' />
+        </div>
+        <div className='space-y-2'>
+          <p className='text-muted-foreground'>
+            我们已向您的邮箱发送了验证邮件，请点击邮件中的链接来验证您的邮箱。
+          </p>
+        </div>
+        <div className='space-y-2'>
+          <p className='text-sm text-muted-foreground'>
+            没有收到邮件？请检查垃圾邮件文件夹，或者重新发送验证邮件。
+          </p>
+        </div>
+      </div>
+    </FailedCard>
+  );
 };
 
 export default ResetPasswordPage;

--- a/frontend/src/shcema/auth.ts
+++ b/frontend/src/shcema/auth.ts
@@ -19,7 +19,7 @@ export const passwordSchema = z
   .refine(p => /[A-Za-z]/.test(p) && /[0-9]/.test(p), {
     message: '密码需包含字母和数字',
   });
-
+export type PasswordField = z.infer<typeof passwordSchema>;
 /**
  * 认证基础表单验证模式
  */
@@ -83,5 +83,7 @@ export type EmailVerificationFormData = z.infer<typeof emailVerificationSchema>;
 /**
  * 邮箱验证
  */
-export const emailSchema = z.email('请输入有效的邮箱地址').transform(e => e.toLowerCase());
+export const emailSchema = z
+  .email('请输入有效的邮箱地址')
+  .transform(e => e.toLowerCase());
 export type EmailFormData = z.infer<typeof emailSchema>;

--- a/frontend/src/shcema/auth.ts
+++ b/frontend/src/shcema/auth.ts
@@ -79,3 +79,9 @@ export const emailVerificationSchema = z.object({
   emailToken: z.string().trim().min(1, '验证令牌不能为空'),
 });
 export type EmailVerificationFormData = z.infer<typeof emailVerificationSchema>;
+
+/**
+ * 邮箱验证
+ */
+export const emailSchema = z.email('请输入有效的邮箱地址').transform(e => e.toLowerCase());
+export type EmailFormData = z.infer<typeof emailSchema>;

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -47,7 +47,7 @@ export interface ForgotPasswordParams {
 
 // 确认重置密码
 export interface ResetPasswordParams {
-  refreshToken: string;
+  resetToken: string;
   newPassword: string;
 }
 


### PR DESCRIPTION
### **描述 (Description)**

本次 Pull Request 的主要目标：

- 实现用户忘记密码流程，包括邮箱验证、发送重置链接、重置密码界面与表单验证。
- 为相关 UI 组件（Button、EmailVerification、ResetPasswordPage、ForgotPasswordPage）添加加载状态与错误展示能力。

此改动涉及的模块：

- `frontend/src/pages/Auth/`（`ForgotPasswordPage`, `ResetPasswordPage`）
- `frontend/src/components/ui/`（`Button` 加载支持）
- `frontend/src/components/common/`（`EmailVerification` 失败卡片组件）
- `frontend/src/api/`（忘记/重置密码相关接口）

---

### **主要变更 (Changes)**

- **新增**: `ResetPasswordPage`（实现重置密码表单、验证与提交逻辑）
- **新增**: 忘记密码流程相关后端调用封装（若位于 `frontend/src/api/auth.ts`）
- **新增**: `EmailVerification` 失败卡片组件用于展示邮箱验证失败信息
- **修改**: `Button` 组件，添加 `loading` 支持与加载指示器
- **修改**: `ForgotPasswordPage`，添加加载状态与交互优化

---

### **影响范围 (Impact)**

- 前端用户认证流程：忘记密码与重置密码功能的用户体验与交互逻辑
- 接口调用：新增/修改与认证相关的 API 调用（发送重置邮件、提交新密码）
- 向下兼容性：对现有登录流程无侵入改动，兼容性风险低