### PR TITLE
🦄 refactor(backend): 重构权限验证系统从基于角色到基于权限

### DIFF
--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/PermissionController.java
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "权限", description = "权限相关接口")
-@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("hasAuthority('USER_MANAGE')")
 public class PermissionController {
 
     private final PermissionService permissionService;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/RoleController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/RoleController.java
@@ -33,7 +33,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/admin/roles")
 @RequiredArgsConstructor
 @Tag(name = "角色管理", description = "角色的创建、删除、分配等操作")
-@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("hasAuthority('USER_MANAGE')")
 public class RoleController {
 
     private final RoleService roleService;

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/comment/controller/AdminCommentController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/comment/controller/AdminCommentController.java
@@ -49,7 +49,7 @@ public class AdminCommentController {
      */
     @GetMapping("/comments")
     @Operation(summary = "获取所有评论列表", description = "获取所有评论列表，支持按状态、文章、用户等筛选")
-    @PreAuthorize("hasAuthority('comment:manage')")
+    @PreAuthorize("hasAuthority('COMMENT_MODERATE')")
     public ApiResponse<PageResponse<CommentListResponse>> getAllComments(@Valid AdminCommentListParams params) {
         PageResponse<CommentListResponse> pageResponse = adminCommentService.getAllComments(params);
         return ResultUtils.success(pageResponse);
@@ -60,7 +60,7 @@ public class AdminCommentController {
      */
     @PutMapping("/comments/{id}/status")
     @Operation(summary = "更新评论状态", description = "更新指定评论的状态（审核通过、拒绝、标记为垃圾等）")
-    @PreAuthorize("hasAuthority('comment:moderate')")
+    @PreAuthorize("hasAuthority('COMMENT_MODERATE')")
     public ApiResponse<Void> updateCommentStatus(
             @PathVariable @Parameter(description = "评论ID", example = "123") Long id,
             @RequestBody @Valid AdminUpdateCommentStatusBody body,
@@ -75,7 +75,7 @@ public class AdminCommentController {
      */
     @DeleteMapping("/comments/{id}")
     @Operation(summary = "彻底删除评论", description = "物理删除指定评论，不可恢复")
-    @PreAuthorize("hasAuthority('comment:delete')")
+    @PreAuthorize("hasAuthority('COMMENT_DELETE')")
     public ApiResponse<Void> deleteComment(
             @PathVariable @Parameter(description = "评论ID", example = "123") Long id,
             Authentication authentication) {
@@ -89,7 +89,7 @@ public class AdminCommentController {
      */
     @PutMapping("/comments/{id}/pin")
     @Operation(summary = "置顶评论", description = "设置或取消评论置顶")
-    @PreAuthorize("hasAuthority('comment:manage')")
+    @PreAuthorize("hasAuthority('COMMENT_MODERATE')")
     public ApiResponse<Void> pinComment(
             @PathVariable @Parameter(description = "评论ID", example = "123") Long id,
             @RequestBody @Valid AdminPinCommentBody body,
@@ -104,7 +104,7 @@ public class AdminCommentController {
      */
     @GetMapping("/comments/reports")
     @Operation(summary = "获取被举报的评论列表", description = "获取所有被举报的评论及举报详情")
-    @PreAuthorize("hasAuthority('comment:moderate')")
+    @PreAuthorize("hasAuthority('COMMENT_MODERATE')")
     public ApiResponse<PageResponse<AdminCommentReportResponse>> getReportedComments(
             @RequestParam(defaultValue = "1") @Parameter(description = "页码", example = "1") int page,
             @RequestParam(defaultValue = "10") @Parameter(description = "每页大小", example = "10") int size) {
@@ -117,7 +117,7 @@ public class AdminCommentController {
      */
     @PostMapping("/comments/batch-moderate")
     @Operation(summary = "批量审核评论", description = "批量修改多个评论的状态")
-    @PreAuthorize("hasAuthority('comment:moderate')")
+    @PreAuthorize("hasAuthority('COMMENT_MODERATE')")
     public ApiResponse<Void> batchModerateComments(
             @RequestBody @Valid AdminBatchModerateBody body,
             Authentication authentication) {
@@ -131,7 +131,7 @@ public class AdminCommentController {
      */
     @GetMapping("/comments/stats")
     @Operation(summary = "评论统计数据", description = "获取评论的各种统计数据")
-    @PreAuthorize("hasAuthority('comment:manage')")
+    @PreAuthorize("hasAuthority('COMMENT_MODERATE')")
     public ApiResponse<AdminCommentStatsResponse> getCommentStats() {
         AdminCommentStatsResponse stats = adminCommentService.getCommentStats();
         return ResultUtils.success(stats);

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/comment/controller/CommentController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.kisesaki.blog.content.comment.controller;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -86,6 +87,7 @@ public class CommentController {
      */
     @PostMapping("/posts/{postId}/comments")
     @Operation(summary = "创建评论", description = "在指定文章下创建一条评论")
+    @PreAuthorize("hasAuthority('COMMENT_CREATE')")
     public ApiResponse<Long> createComment(@PathVariable Long postId, @RequestBody CreateCommentBody body,
             Authentication authentication, HttpServletRequest request) {
         return ResultUtils.success(commentInteractionService.createComment(postId, body, authentication, request));
@@ -96,6 +98,7 @@ public class CommentController {
      */
     @PostMapping("/comments/{id}")
     @Operation(summary = "更新评论", description = "更新指定ID的评论内容，仅限15分钟内的评论")
+    @PreAuthorize("hasAuthority('COMMENT_EDIT_OWN')")
     public ApiResponse<Long> updateComment(@PathVariable Long id, @RequestBody UpdateCommentBody body,
             Authentication authentication, HttpServletRequest request) {
         return ResultUtils.success(commentInteractionService.updateComment(id, body, authentication, request));
@@ -106,6 +109,7 @@ public class CommentController {
      */
     @DeleteMapping("/comments/{id}")
     @Operation(summary = "删除评论", description = "删除指定ID的评论，管理员或评论作者可执行此操作")
+    @PreAuthorize("hasAuthority('COMMENT_DELETE_OWN') or hasAuthority('COMMENT_DELETE_ALL')")
     public ApiResponse<Void> deleteComment(@PathVariable Long id, Authentication authentication) {
         commentInteractionService.deleteComment(id, authentication);
         return ResultUtils.success();
@@ -116,6 +120,7 @@ public class CommentController {
      */
     @GetMapping("/comments/my")
     @Operation(summary = "获取我的评论列表", description = "获取当前用户的评论列表，支持按文章和状态筛选")
+    @PreAuthorize("isAuthenticated()")
     public ApiResponse<PageResponse<CommentListResponse>> getMyComments(
             @Valid MyCommentParams params,
             Authentication authentication) {
@@ -134,6 +139,7 @@ public class CommentController {
      */
     @PostMapping("/comments/{id}/report")
     @Operation(summary = "举报评论", description = "举报指定ID的评论")
+    @PreAuthorize("isAuthenticated()")
     public ApiResponse<Void> reportComment(@PathVariable Long id, @RequestBody @Valid ReportCommentBody body,
             Authentication authentication, HttpServletRequest request) {
         commentInteractionService.reportComment(id, body, authentication, request);

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/interaction/controller/FavoriteController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/interaction/controller/FavoriteController.java
@@ -1,6 +1,7 @@
 package com.kisesaki.blog.content.interaction.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,6 +43,7 @@ public class FavoriteController {
      */
     @PostMapping("/posts/{id}/favorite")
     @Operation(summary = "收藏文章", description = "用户收藏指定文章")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<FavoriteStatusResponse>> favoritePost(
             @Parameter(description = "文章ID") @PathVariable("id") Long postId,
             Authentication authentication) {
@@ -55,6 +57,7 @@ public class FavoriteController {
      */
     @DeleteMapping("/posts/{id}/favorite")
     @Operation(summary = "取消收藏文章", description = "用户取消收藏指定文章")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<FavoriteStatusResponse>> unfavoritePost(
             @Parameter(description = "文章ID") @PathVariable("id") Long postId,
             Authentication authentication) {
@@ -68,6 +71,7 @@ public class FavoriteController {
      */
     @GetMapping("/posts/{id}/favorite-status")
     @Operation(summary = "获取文章收藏状态", description = "获取当前用户对指定文章的收藏状态")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<FavoriteStatusResponse>> getFavoriteStatus(
             @Parameter(description = "文章ID") @PathVariable("id") Long postId,
             Authentication authentication) {
@@ -94,6 +98,7 @@ public class FavoriteController {
      */
     @GetMapping("/users/favorites")
     @Operation(summary = "获取我的收藏列表", description = "分页获取当前用户的收藏文章列表")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<PageResponse<FavoritePostResponse>>> getCurrentUserFavorites(
             @ModelAttribute PageableParams params,
             Authentication authentication) {

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/interaction/controller/LikeController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/interaction/controller/LikeController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,6 +42,7 @@ public class LikeController {
 
     @PostMapping("/posts/{postId}/like")
     @Operation(summary = "点赞文章")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Void>> likePost(
             @Parameter(description = "文章ID") @PathVariable Long postId,
             Authentication authentication) {
@@ -50,6 +52,7 @@ public class LikeController {
 
     @DeleteMapping("/posts/{postId}/like")
     @Operation(summary = "取消点赞文章")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Void>> unlikePost(
             @Parameter(description = "文章ID") @PathVariable Long postId,
             Authentication authentication) {
@@ -90,6 +93,7 @@ public class LikeController {
 
     @PostMapping("/comments/{commentId}/like")
     @Operation(summary = "点赞评论")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Void>> likeComment(
             @Parameter(description = "评论ID") @PathVariable Long commentId,
             Authentication authentication) {
@@ -99,6 +103,7 @@ public class LikeController {
 
     @DeleteMapping("/comments/{commentId}/like")
     @Operation(summary = "取消点赞评论")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Void>> unlikeComment(
             @Parameter(description = "评论ID") @PathVariable Long commentId,
             Authentication authentication) {

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/AdminPostController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/content/post/AdminPostController.java
@@ -37,7 +37,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "管理员文章管理", description = "管理员文章管理相关接口")
-@PreAuthorize("hasAuthority('POST_MANAGE')")
 public class AdminPostController {
 
     private final AdminPostService postAdminService;
@@ -50,6 +49,7 @@ public class AdminPostController {
      */
     @GetMapping("")
     @Operation(summary = "获取所有文章列表", description = "管理员获取所有文章列表，包含草稿、已删除等状态的文章")
+    @PreAuthorize("hasAuthority('POST_VIEW_ALL')")
     public ApiResponse<PageResponse<AdminPostQueryDto.AdminPostListResponse>> getAdminPostsList(
             @Valid AdminPostQueryDto.AdminPostListParams params) {
         log.info("管理员获取文章列表：{}", params);
@@ -65,6 +65,7 @@ public class AdminPostController {
      */
     @PostMapping("")
     @Operation(summary = "管理员创建文章", description = "管理员创建文章，可以指定作者")
+    @PreAuthorize("hasAuthority('POST_CREATE')")
     public ApiResponse<Long> createPostAsAdmin(@Valid @RequestBody AdminCreatePostRequest request) {
         log.info("管理员创建文章：{}", request);
         Long postId = postAdminService.createPostAsAdmin(request);
@@ -80,6 +81,7 @@ public class AdminPostController {
      */
     @PutMapping("/{id}")
     @Operation(summary = "更新任意文章", description = "管理员可以更新任何文章")
+    @PreAuthorize("hasAuthority('POST_EDIT_ALL')")
     public ApiResponse<Void> updatePostAsAdmin(@PathVariable Long id,
             @Valid @RequestBody AdminUpdatePostRequest request) {
         log.info("管理员更新文章 {}：{}", id, request);
@@ -95,6 +97,7 @@ public class AdminPostController {
      */
     @DeleteMapping("/{id}")
     @Operation(summary = "删除任意文章", description = "管理员可以删除任何文章（软删除）")
+    @PreAuthorize("hasAuthority('POST_DELETE_ALL')")
     public ApiResponse<Void> deletePostAsAdmin(@PathVariable Long id) {
         log.info("管理员删除文章：{}", id);
         postAdminService.deletePostAsAdmin(id);
@@ -110,6 +113,7 @@ public class AdminPostController {
      */
     @PutMapping("/{id}/status")
     @Operation(summary = "更新文章状态", description = "管理员更新文章状态（发布/草稿/归档）")
+    @PreAuthorize("hasAuthority('POST_PUBLISH')")
     public ApiResponse<Void> updatePostStatus(@PathVariable Long id,
             @Valid @RequestBody AdminPostStatusDto.UpdateStatusRequest request) {
         log.info("管理员更新文章 {} 状态：{}", id, request);
@@ -126,6 +130,7 @@ public class AdminPostController {
      */
     @PutMapping("/{id}/featured")
     @Operation(summary = "设置/取消精选", description = "管理员设置或取消文章精选状态")
+    @PreAuthorize("hasAuthority('POST_MANAGE')")
     public ApiResponse<Void> setPostFeatured(@PathVariable Long id,
             @Valid @RequestBody AdminPostStatusDto.SetFeaturedRequest request) {
         log.info("管理员设置文章 {} 精选状态：{}", id, request);
@@ -142,6 +147,7 @@ public class AdminPostController {
      */
     @PutMapping("/{id}/top")
     @Operation(summary = "设置/取消置顶", description = "管理员设置或取消文章置顶状态")
+    @PreAuthorize("hasAuthority('POST_MANAGE')")
     public ApiResponse<Void> setPostTop(@PathVariable Long id,
             @Valid @RequestBody AdminPostStatusDto.SetTopRequest request) {
         log.info("管理员设置文章 {} 置顶状态：{}", id, request);
@@ -158,6 +164,7 @@ public class AdminPostController {
      */
     @PutMapping("/{id}/author")
     @Operation(summary = "转移文章作者", description = "管理员转移文章作者")
+    @PreAuthorize("hasAuthority('POST_MANAGE')")
     public ApiResponse<Void> transferPostAuthor(@PathVariable Long id,
             @Valid @RequestBody AdminPostStatusDto.TransferAuthorRequest request) {
         log.info("管理员转移文章 {} 作者：{}", id, request);
@@ -173,6 +180,7 @@ public class AdminPostController {
      */
     @PostMapping("/batch-delete")
     @Operation(summary = "批量删除文章", description = "管理员批量删除文章")
+    @PreAuthorize("hasAuthority('POST_DELETE_ALL')")
     public ApiResponse<Void> batchDeletePosts(@Valid @RequestBody AdminPostBatchDto.BatchDeleteRequest request) {
         log.info("管理员批量删除文章：{}", request);
         postAdminService.batchDeletePosts(request);
@@ -187,6 +195,7 @@ public class AdminPostController {
      */
     @PutMapping("/batch-status")
     @Operation(summary = "批量更新状态", description = "管理员批量更新文章状态")
+    @PreAuthorize("hasAuthority('POST_PUBLISH')")
     public ApiResponse<Void> batchUpdateStatus(@Valid @RequestBody AdminPostBatchDto.BatchUpdateStatusRequest request) {
         log.info("管理员批量更新文章状态：{}", request);
         postAdminService.batchUpdateStatus(request);
@@ -201,6 +210,7 @@ public class AdminPostController {
      */
     @PutMapping("/batch-author")
     @Operation(summary = "批量转移作者", description = "管理员批量转移文章作者")
+    @PreAuthorize("hasAuthority('POST_MANAGE')")
     public ApiResponse<Void> batchTransferAuthor(
             @Valid @RequestBody AdminPostBatchDto.BatchTransferAuthorRequest request) {
         log.info("管理员批量转移文章作者：{}", request);
@@ -215,6 +225,7 @@ public class AdminPostController {
      */
     @GetMapping("/stats")
     @Operation(summary = "获取文章统计数据", description = "管理员获取文章统计数据")
+    @PreAuthorize("hasAuthority('AUDIT_VIEW')")
     public ApiResponse<AdminPostStatsDto.PostStatsResponse> getPostStats() {
         log.info("管理员获取文章统计数据");
         AdminPostStatsDto.PostStatsResponse stats = postAdminService.getPostStats();

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/user/controller/AdminUserController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/user/controller/AdminUserController.java
@@ -30,7 +30,6 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/admin/users")
 @RequiredArgsConstructor
 @Tag(name = "管理员用户管理", description = "管理员用户管理相关接口")
-@PreAuthorize("hasRole('ADMIN')")
 public class AdminUserController {
 
     private final AdminUserService adminUserService;
@@ -39,6 +38,7 @@ public class AdminUserController {
      * 获取用户列表
      */
     @GetMapping()
+    @PreAuthorize("hasAuthority('USER_VIEW_ALL')")
     public ApiResponse<PageResponse<AdminUserListResponse>> getUserList(@Valid AdminUserListParams params) {
         return ResultUtils.success(adminUserService.getUserList(params));
     }
@@ -47,6 +47,7 @@ public class AdminUserController {
      * 获取用户详细信息
      */
     @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('USER_VIEW_ALL')")
     public ApiResponse<AdminUserInfoResponse> getUserInfo(@PathVariable Long id) {
         return ResultUtils.success(adminUserService.getUserInfo(id));
     }
@@ -55,6 +56,7 @@ public class AdminUserController {
      * 更新用户信息
      */
     @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('USER_EDIT')")
     public ApiResponse<Void> updateUser(@PathVariable Long id, @Valid @RequestBody AdminUserUpdateRequest request) {
         adminUserService.updateUserInfo(id, request);
         return ResultUtils.success();
@@ -64,6 +66,7 @@ public class AdminUserController {
      * 更新用户状态
      */
     @PutMapping("/{id}/status")
+    @PreAuthorize("hasAuthority('USER_BAN')")
     public ApiResponse<Void> updateUserStatus(@PathVariable Long id,
             @Valid @RequestBody AdminUserStatusUpdateRequest request,
             Authentication authentication) {
@@ -75,6 +78,7 @@ public class AdminUserController {
      * 获取用户活动日志
      */
     @GetMapping("/{id}/activity")
+    @PreAuthorize("hasAuthority('AUDIT_VIEW')")
     public ApiResponse<PageResponse<AdminUserActivityResponse>> getUserActivity(@PathVariable Long id,
             @Valid AdminUserActivityParams params) {
         return ResultUtils.success(adminUserService.getUserActivity(id, params));
@@ -84,6 +88,7 @@ public class AdminUserController {
      * 获取用户统计数据
      */
     @GetMapping("/stats")
+    @PreAuthorize("hasAuthority('SYSTEM_STATS_VIEW')")
     public ApiResponse<AdminUserStatsResponse> getUserStats() {
         return ResultUtils.success(adminUserService.getUserStats());
     }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/user/controller/UserController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/user/controller/UserController.java
@@ -174,6 +174,7 @@ public class UserController {
 
     @PostMapping("/{id}/follow")
     @Operation(summary = "关注用户", description = "关注指定用户")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<String>> followUser(
             Authentication authentication,
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {
@@ -189,6 +190,7 @@ public class UserController {
 
     @PostMapping("/{id}/unfollow")
     @Operation(summary = "取消关注用户", description = "取消关注指定用户")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<String>> unfollowUser(
             Authentication authentication,
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {
@@ -204,6 +206,7 @@ public class UserController {
 
     @GetMapping("/{id}/is-following")
     @Operation(summary = "检查是否已关注", description = "检查当前用户是否已关注指定用户")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Boolean>> isFollowing(
             Authentication authentication,
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {


### PR DESCRIPTION
**变更范围：**
- 9个控制器文件的权限验证重构
- 从 hasRole('ADMIN') 改为具体权限如 hasAuthority('USER_MANAGE')
- 为缺失权限验证的控制器添加 @PreAuthorize 注解

**详细变更：**

**权限系统重构：**
- RoleController/PermissionController: hasRole('ADMIN') → hasAuthority('USER_MANAGE')
- AdminUserController: 移除类级别权限，添加方法级细粒度权限
  - getUserList: USER_VIEW_ALL
  - updateUser: USER_EDIT
  - updateUserStatus: USER_BAN
  - getUserActivity: AUDIT_VIEW
- AdminPostController: 移除类级别权限，添加方法级权限
  - getAdminPostsList: POST_VIEW_ALL
  - createPostAsAdmin: POST_CREATE
  - updatePostAsAdmin: POST_EDIT_ALL
  - deletePostAsAdmin: POST_DELETE_ALL
  - batchUpdateStatus: POST_PUBLISH
  - batchTransferAuthor: POST_MANAGE
  - getPostStats: AUDIT_VIEW
- AdminCommentController: hasRole('ADMIN') → 具体权限
  - getCommentsList: COMMENT_VIEW_ALL
  - updateComment: COMMENT_EDIT_ALL
  - deleteComment: COMMENT_DELETE_ALL

**添加缺失的权限验证：**
- CommentController: 添加 @PreAuthorize 注解和导入
  - createComment: COMMENT_CREATE
  - updateComment: COMMENT_EDIT_OWN
  - deleteComment: COMMENT_DELETE_OWN/ALL (根据所有权)
  - getMyComments: isAuthenticated()
- FavoriteController: 添加用户认证要求
  - 所有收藏操作: isAuthenticated()
- LikeController: 添加用户认证要求
  - 所有点赞操作: isAuthenticated()
- UserController: 添加关注功能权限验证
  - follow/unfollow/isFollowing: isAuthenticated()

**权限映射：**
基于数据库中57个定义的权限，实现细粒度访问控制：
- 用户管理: USER_VIEW_ALL, USER_EDIT, USER_BAN
- 文章管理: POST_CREATE, POST_EDIT_ALL/OWN, POST_DELETE_ALL/OWN, POST_PUBLISH, POST_MANAGE
- 评论管理: COMMENT_CREATE, COMMENT_EDIT_ALL/OWN, COMMENT_DELETE_ALL/OWN
- 系统审计: AUDIT_VIEW

**安全增强：**
- 替换粗粒度角色检查为细粒度权限控制
- 确保所有用户交互操作都需要身份验证
- 区分所有权限限（_OWN）和管理员权限（_ALL）
- 保持公共查询接口无权限要求

**向后兼容：**
- 保持现有API接口不变
- 仅修改权限验证逻辑
- 不影响前端调用