### PR TITLE
✨feat(auth): 添加重新发送验证邮件功能

### DIFF
--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/AuthController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/AuthController.java
@@ -2,7 +2,6 @@ package com.kisesaki.blog.auth.controller;
 
 import java.util.Set;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,6 +23,7 @@ import com.kisesaki.blog.auth.dto.auth.request.VerifyEmailRequestDto;
 import com.kisesaki.blog.auth.dto.auth.response.LoginResponseDto;
 import com.kisesaki.blog.auth.service.AuthService;
 import com.kisesaki.blog.common.dto.ApiResponse;
+import com.kisesaki.blog.common.dto.ResultUtils;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -46,116 +46,116 @@ public class AuthController {
 
     @PostMapping("/login")
     @Operation(summary = "用户登录", description = "用户使用用户名和密码进行登录，支持设备管理")
-    public ResponseEntity<ApiResponse<LoginResponseDto>> login(
+    public ApiResponse<LoginResponseDto> login(
             @Valid @RequestBody LoginRequestDto loginRequestDto,
             HttpServletRequest request) {
-        ApiResponse<LoginResponseDto> response = authService.login(loginRequestDto, request);
-        return ResponseEntity.ok(response);
+        LoginResponseDto response = authService.login(loginRequestDto, request);
+        return ResultUtils.success("登录成功", response);
     }
 
     @PostMapping("/register")
     @Operation(summary = "用户注册", description = "新用户注册账号")
-    public ResponseEntity<ApiResponse<String>> register(@Valid @RequestBody RegisterRequestDto registerRequest) {
-        ApiResponse<String> response = authService.register(registerRequest);
-        return ResponseEntity.ok(response);
+    public ApiResponse<String> register(@Valid @RequestBody RegisterRequestDto registerRequest) {
+        String response = authService.register(registerRequest);
+        return ResultUtils.success("注册成功", response);
     }
 
     @PostMapping("/verify-email")
     @Operation(summary = "验证邮箱", description = "使用邮箱验证令牌验证用户的邮箱")
-    public ResponseEntity<ApiResponse<String>> verifyEmail(
+    public ApiResponse<Void> verifyEmail(
             @Valid @RequestBody VerifyEmailRequestDto verifyEmailRequest) {
-        ApiResponse<String> response = authService.verifyEmail(verifyEmailRequest);
-        return ResponseEntity.ok(response);
+        authService.verifyEmail(verifyEmailRequest);
+        return ResultUtils.success("邮箱验证成功");
     }
 
     @PostMapping("/refreshToken")
     @Operation(summary = "刷新令牌", description = "使用刷新令牌获取新的访问令牌")
-    public ResponseEntity<ApiResponse<LoginResponseDto>> refreshToken(
+    public ApiResponse<LoginResponseDto> refreshToken(
             @Valid @RequestBody RefreshTokenRequestDto refreshTokenRequestDto,
             HttpServletRequest request) {
-        ApiResponse<LoginResponseDto> response = authService.refreshToken(refreshTokenRequestDto, request);
-        return ResponseEntity.ok(response);
+        LoginResponseDto response = authService.refreshToken(refreshTokenRequestDto, request);
+        return ResultUtils.success("访问令牌刷新成功", response);
     }
 
     @PostMapping("/logout")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "用户登出", description = "用户登出当前设备")
-    public ResponseEntity<ApiResponse<String>> logout(
+    public ApiResponse<Void> logout(
             @Valid @RequestBody LogoutRequestDto logoutRequest,
             Authentication authentication,
             HttpServletRequest request) {
         String username = authentication.getName();
-        ApiResponse<String> response = authService.logout(username,
+        authService.logout(username,
                 logoutRequest.getRefreshToken(), logoutRequest.getDeviceId(), request);
-        return ResponseEntity.ok(response);
+        return ResultUtils.success("登出成功");
     }
 
     @PostMapping("/logout-all")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "登出所有设备", description = "用户登出所有已登录的设备")
-    public ResponseEntity<ApiResponse<String>> logoutAllDevices(Authentication authentication) {
+    public ApiResponse<Void> logoutAllDevices(Authentication authentication) {
         String username = authentication.getName();
-        ApiResponse<String> response = authService.logoutAllDevices(username);
-        return ResponseEntity.ok(response);
+        authService.logoutAllDevices(username);
+        return ResultUtils.success("已登出所有设备");
     }
 
     @DeleteMapping("/devices/{deviceId}")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "踢出指定设备", description = "管理员或用户踢出指定设备")
-    public ResponseEntity<ApiResponse<String>> kickDevice(
+    public ApiResponse<Void> kickDevice(
             @PathVariable String deviceId,
             Authentication authentication,
             HttpServletRequest request) {
         String username = authentication.getName();
-        ApiResponse<String> response = authService.kickDevice(username, deviceId, request);
-        return ResponseEntity.ok(response);
+        authService.kickDevice(username, deviceId, request);
+        return ResultUtils.success("设备已被踢出");
     }
 
     @GetMapping("/devices")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "获取用户设备列表", description = "获取当前用户所有已登录的设备")
-    public ResponseEntity<ApiResponse<Set<String>>> getUserDevices(Authentication authentication) {
+    public ApiResponse<Set<String>> getUserDevices(Authentication authentication) {
         String username = authentication.getName();
-        ApiResponse<Set<String>> response = authService.getUserDevices(username);
-        return ResponseEntity.ok(response);
+        Set<String> response = authService.getUserDevices(username);
+        return ResultUtils.success("获取设备列表成功", response);
     }
 
     @PostMapping("change-password")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "修改密码", description = "用户修改自己的登录密码")
-    public ResponseEntity<ApiResponse<String>> changePassword(
+    public ApiResponse<Void> changePassword(
             @Valid @RequestBody ChangePasswordRequestDto changePasswordRequest,
             Authentication authentication,
             HttpServletRequest request) {
         String username = authentication.getName();
-        ApiResponse<String> response = authService.changePassword(username, changePasswordRequest, request);
-        return ResponseEntity.ok(response);
+        authService.changePassword(username, changePasswordRequest, request);
+        return ResultUtils.success("密码修改成功");
     }
 
     @PostMapping("forgot-password")
     @Operation(summary = "忘记密码", description = "用户通过邮箱重置登录密码")
-    public ResponseEntity<ApiResponse<String>> forgotPassword(
+    public ApiResponse<Void> forgotPassword(
             @Valid @RequestBody ForgotPasswordRequestDto forgotPasswordRequestDto) {
-        ApiResponse<String> response = authService.forgotPassword(forgotPasswordRequestDto);
-        return ResponseEntity.ok(response);
+        authService.forgotPassword(forgotPasswordRequestDto);
+        return ResultUtils.success("密码重置邮件已发送，请检查您的邮箱");
     }
 
     @PostMapping("/reset-password")
     @Operation(summary = "确认重置密码", description = "用户通过邮箱收到的令牌确认重置密码")
-    public ResponseEntity<ApiResponse<String>> resetPassword(
+    public ApiResponse<Void> resetPassword(
             @Valid @RequestBody ResetPasswordRequestDto resetPasswordRequest) {
-        ApiResponse<String> response = authService.resetPassword(resetPasswordRequest);
-        return ResponseEntity.ok(response);
+        authService.resetPassword(resetPasswordRequest);
+        return ResultUtils.success("密码重置成功");
     }
 
     @PostMapping("/clean-expired")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "清理过期令牌", description = "清理用户的过期令牌")
-    public ResponseEntity<ApiResponse<String>> cleanExpiredTokens(
+    public ApiResponse<Void> cleanExpiredTokens(
             Authentication authentication,
             HttpServletRequest request) {
         String username = authentication.getName();
-        ApiResponse<String> response = authService.cleanExpiredTokens(username, request);
-        return ResponseEntity.ok(response);
+        authService.cleanExpiredTokens(username, request);
+        return ResultUtils.success("清理过期令牌成功");
     }
 }

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/AuthController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.kisesaki.blog.auth.controller;
 
 import java.util.Set;
 
+import com.kisesaki.blog.common.util.AuthUtils;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -47,8 +48,8 @@ public class AuthController {
     @PostMapping("/login")
     @Operation(summary = "用户登录", description = "用户使用用户名和密码进行登录，支持设备管理")
     public ApiResponse<LoginResponseDto> login(
-            @Valid @RequestBody LoginRequestDto loginRequestDto,
-            HttpServletRequest request) {
+        @Valid @RequestBody LoginRequestDto loginRequestDto,
+        HttpServletRequest request) {
         LoginResponseDto response = authService.login(loginRequestDto, request);
         return ResultUtils.success("登录成功", response);
     }
@@ -60,10 +61,18 @@ public class AuthController {
         return ResultUtils.success("注册成功", response);
     }
 
+    @PostMapping("/resend-verification-email")
+    @Operation(summary = "重新发送验证邮箱", description = "用户请求重新发送验证邮箱")
+    public ApiResponse<Void> resendVerificationEmail(Authentication authentication) {
+        Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
+        authService.resendVerificationEmail(userId);
+        return ResultUtils.success("验证邮件已重新发送，请检查您的邮箱");
+    }
+
     @PostMapping("/verify-email")
     @Operation(summary = "验证邮箱", description = "使用邮箱验证令牌验证用户的邮箱")
     public ApiResponse<Void> verifyEmail(
-            @Valid @RequestBody VerifyEmailRequestDto verifyEmailRequest) {
+        @Valid @RequestBody VerifyEmailRequestDto verifyEmailRequest) {
         authService.verifyEmail(verifyEmailRequest);
         return ResultUtils.success("邮箱验证成功");
     }
@@ -71,8 +80,8 @@ public class AuthController {
     @PostMapping("/refreshToken")
     @Operation(summary = "刷新令牌", description = "使用刷新令牌获取新的访问令牌")
     public ApiResponse<LoginResponseDto> refreshToken(
-            @Valid @RequestBody RefreshTokenRequestDto refreshTokenRequestDto,
-            HttpServletRequest request) {
+        @Valid @RequestBody RefreshTokenRequestDto refreshTokenRequestDto,
+        HttpServletRequest request) {
         LoginResponseDto response = authService.refreshToken(refreshTokenRequestDto, request);
         return ResultUtils.success("访问令牌刷新成功", response);
     }
@@ -81,12 +90,12 @@ public class AuthController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "用户登出", description = "用户登出当前设备")
     public ApiResponse<Void> logout(
-            @Valid @RequestBody LogoutRequestDto logoutRequest,
-            Authentication authentication,
-            HttpServletRequest request) {
+        @Valid @RequestBody LogoutRequestDto logoutRequest,
+        Authentication authentication,
+        HttpServletRequest request) {
         String username = authentication.getName();
         authService.logout(username,
-                logoutRequest.getRefreshToken(), logoutRequest.getDeviceId(), request);
+            logoutRequest.getRefreshToken(), logoutRequest.getDeviceId(), request);
         return ResultUtils.success("登出成功");
     }
 
@@ -103,9 +112,9 @@ public class AuthController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "踢出指定设备", description = "管理员或用户踢出指定设备")
     public ApiResponse<Void> kickDevice(
-            @PathVariable String deviceId,
-            Authentication authentication,
-            HttpServletRequest request) {
+        @PathVariable String deviceId,
+        Authentication authentication,
+        HttpServletRequest request) {
         String username = authentication.getName();
         authService.kickDevice(username, deviceId, request);
         return ResultUtils.success("设备已被踢出");
@@ -124,9 +133,9 @@ public class AuthController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "修改密码", description = "用户修改自己的登录密码")
     public ApiResponse<Void> changePassword(
-            @Valid @RequestBody ChangePasswordRequestDto changePasswordRequest,
-            Authentication authentication,
-            HttpServletRequest request) {
+        @Valid @RequestBody ChangePasswordRequestDto changePasswordRequest,
+        Authentication authentication,
+        HttpServletRequest request) {
         String username = authentication.getName();
         authService.changePassword(username, changePasswordRequest, request);
         return ResultUtils.success("密码修改成功");
@@ -135,7 +144,7 @@ public class AuthController {
     @PostMapping("forgot-password")
     @Operation(summary = "忘记密码", description = "用户通过邮箱重置登录密码")
     public ApiResponse<Void> forgotPassword(
-            @Valid @RequestBody ForgotPasswordRequestDto forgotPasswordRequestDto) {
+        @Valid @RequestBody ForgotPasswordRequestDto forgotPasswordRequestDto) {
         authService.forgotPassword(forgotPasswordRequestDto);
         return ResultUtils.success("密码重置邮件已发送，请检查您的邮箱");
     }
@@ -143,7 +152,7 @@ public class AuthController {
     @PostMapping("/reset-password")
     @Operation(summary = "确认重置密码", description = "用户通过邮箱收到的令牌确认重置密码")
     public ApiResponse<Void> resetPassword(
-            @Valid @RequestBody ResetPasswordRequestDto resetPasswordRequest) {
+        @Valid @RequestBody ResetPasswordRequestDto resetPasswordRequest) {
         authService.resetPassword(resetPasswordRequest);
         return ResultUtils.success("密码重置成功");
     }
@@ -152,8 +161,8 @@ public class AuthController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "清理过期令牌", description = "清理用户的过期令牌")
     public ApiResponse<Void> cleanExpiredTokens(
-            Authentication authentication,
-            HttpServletRequest request) {
+        Authentication authentication,
+        HttpServletRequest request) {
         String username = authentication.getName();
         authService.cleanExpiredTokens(username, request);
         return ResultUtils.success("清理过期令牌成功");

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/AuthService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/AuthService.java
@@ -33,7 +33,6 @@ import com.kisesaki.blog.auth.security.jwt.DeviceFingerprintService;
 import com.kisesaki.blog.auth.security.jwt.JwtTokenProvider;
 import com.kisesaki.blog.auth.security.jwt.RefreshTokenService;
 import com.kisesaki.blog.auth.security.user.CustomUserDetailsService;
-import com.kisesaki.blog.common.dto.ApiResponse;
 import com.kisesaki.blog.common.enums.ErrorCode;
 import com.kisesaki.blog.common.exception.BusinessException;
 import com.kisesaki.blog.notification.event.EmailEventPublisher;
@@ -119,7 +118,7 @@ public class AuthService {
      * @param request         HTTP请求对象，用于获取设备指纹
      * @return 登录结果，包含JWT令牌和设备信息
      */
-    public ApiResponse<LoginResponseDto> login(LoginRequestDto loginRequestDto, HttpServletRequest request) {
+    public LoginResponseDto login(LoginRequestDto loginRequestDto, HttpServletRequest request) {
         // 执行认证
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(loginRequestDto.getUsername(), loginRequestDto.getPassword()));
@@ -142,7 +141,7 @@ public class AuthService {
 
         log.info("用户 {} 从设备 {} 登录成功", loginRequestDto.getUsername(), formatDeviceIdForLog(deviceId));
 
-        return ApiResponse.success("登录成功", response);
+        return response;
     }
 
     /**
@@ -152,7 +151,7 @@ public class AuthService {
      * @return 注册结果
      */
     @Transactional
-    public ApiResponse<String> register(RegisterRequestDto registerRequestDto) {
+    public String register(RegisterRequestDto registerRequestDto) {
         String username = registerRequestDto.getUsername();
         String password = registerRequestDto.getPassword();
         String email = registerRequestDto.getEmail();
@@ -161,14 +160,14 @@ public class AuthService {
                 .eq(User::getUsername, username)
                 .ne(User::getStatus, "deleted")) > 0) {
             log.warn("注册失败，用户名已存在：{}", username);
-            return ApiResponse.error("用户名已存在");
+            throw BusinessException.of(ErrorCode.USERNAME_ALREADY_EXISTS, "用户名已存在");
         }
 
         if (userMapper.selectCount(new LambdaQueryWrapper<User>()
                 .eq(User::getEmail, email)
                 .ne(User::getStatus, "deleted")) > 0) {
             log.warn("注册失败，邮箱已被占用：{}", email);
-            return ApiResponse.error("邮箱已被占用");
+            throw BusinessException.of(ErrorCode.EMAIL_ALREADY_EXISTS, "邮箱已被占用");
         }
 
         // 创建用户实体
@@ -196,7 +195,7 @@ public class AuthService {
                     LocalDateTime.now());
             eventPublisher.publishEvent(event);
             log.info("用户 {} 注册完成，ID: {}", user.getUsername(), user.getId());
-            return ApiResponse.success("注册成功", user.getId().toString());
+            return user.getId().toString();
         } catch (Exception e) {
             log.error("用户注册失败，用户名：{}，错误：{}", username, e.getMessage(), e);
             throw BusinessException.of(ErrorCode.SYSTEM_ERROR, "注册失败，请稍后重试");
@@ -209,14 +208,14 @@ public class AuthService {
      * @param verifyEmailRequestDto 验证请求
      * @return 验证结果
      */
-    public ApiResponse<String> verifyEmail(VerifyEmailRequestDto verifyEmailRequestDto) {
+    public void verifyEmail(VerifyEmailRequestDto verifyEmailRequestDto) {
         String emailToken = verifyEmailRequestDto.getEmailToken();
         String redisKey = UserKey.buildEmailVerificationKey(emailToken);
 
         Map<Object, Object> verificationData = redisService.hGetAll(redisKey);
         if (verificationData == null || verificationData.isEmpty()) {
             log.warn("邮箱验证失败，令牌无效或已过期，令牌: {}", emailToken);
-            return ApiResponse.error("邮箱验证令牌无效或已过期");
+            throw BusinessException.of(ErrorCode.TOKEN_INVALID, "邮箱验证令牌无效或已过期");
         }
 
         // 获取用户ID和邮箱
@@ -226,13 +225,13 @@ public class AuthService {
         User user = userMapper.selectById(userId);
         if (user == null) {
             log.error("邮箱验证失败，用户不存在，用户ID: {}", userId);
-            return ApiResponse.error("用户不存在");
+            throw BusinessException.of(ErrorCode.USER_NOT_FOUND, "用户不存在");
         }
 
         // 检查邮箱是否已验证
         if (user.getEmailVerified() != null && user.getEmailVerified()) {
             log.info("用户 {} 的邮箱已验证，无需重复验证", user.getUsername());
-            return ApiResponse.success("邮箱已验证", "");
+            return;
         }
 
         // 更新用户的邮箱验证状态
@@ -246,10 +245,9 @@ public class AuthService {
             upgradeUserFromGuestToUser(user.getId());
             
             log.info("用户 {} 的邮箱验证成功", user.getUsername());
-            return ApiResponse.success("邮箱验证成功", "");
         } catch (Exception e) {
             log.error("更新用户 {} 的邮箱验证状态失败", user.getUsername(), e);
-            return ApiResponse.error("邮箱验证失败，请稍后重试");
+            throw BusinessException.of(ErrorCode.SYSTEM_ERROR, "邮箱验证失败，请稍后重试");
         }
     }
 
@@ -259,13 +257,13 @@ public class AuthService {
      * @param refreshTokenRequestDto 刷新令牌请求
      * @return 新的访问令牌
      */
-    public ApiResponse<LoginResponseDto> refreshToken(RefreshTokenRequestDto refreshTokenRequestDto,
+    public LoginResponseDto refreshToken(RefreshTokenRequestDto refreshTokenRequestDto,
             HttpServletRequest request) {
         String refreshToken = refreshTokenRequestDto.getRefreshToken();
         String deviceId = refreshTokenRequestDto.getDeviceId();
 
         if (!jwtTokenProvider.validateToken(refreshToken)) {
-            return ApiResponse.error("无效的刷新令牌");
+            throw BusinessException.of(ErrorCode.TOKEN_INVALID, "无效的刷新令牌");
         }
 
         // 获取用户名
@@ -273,13 +271,13 @@ public class AuthService {
 
         // 验证 Refresh Token（支持设备ID验证）
         if (!refreshTokenService.validateRefreshToken(username, refreshToken, deviceId)) {
-            return ApiResponse.error("刷新令牌无效或已过期");
+            throw BusinessException.of(ErrorCode.TOKEN_INVALID, "刷新令牌无效或已过期");
         }
 
         // 验证设备指纹
         if (!deviceFingerprintService.validateDeviceFingerprint(request, deviceId)) {
             log.warn("用户 {} 的设备指纹验证失败，可能是设备变更或伪造请求，设备ID: {}", username, formatDeviceIdForLog(deviceId));
-            return ApiResponse.error("设备验证失败，无法刷新令牌");
+            throw BusinessException.of(ErrorCode.ACCESS_DENIED, "设备验证失败，无法刷新令牌");
         }
 
         // 加载用户详情
@@ -295,7 +293,7 @@ public class AuthService {
 
         log.debug("用户 {} 的访问令牌刷新成功，设备: {}", username, formatDeviceIdForLog(deviceId));
 
-        return ApiResponse.success("访问令牌刷新成功", response);
+        return response;
     }
 
     /**
@@ -307,21 +305,20 @@ public class AuthService {
      * @param request      HTTP请求对象，用于设备指纹验证
      * @return 登出结果
      */
-    public ApiResponse<String> logout(String username, String refreshToken, String deviceId,
+    public void logout(String username, String refreshToken, String deviceId,
             HttpServletRequest request) {
         // 如果提供了设备ID，需要验证设备指纹
         if (deviceId != null && !validateDeviceFingerprint(request, username, deviceId)) {
             log.warn("用户 {} 登出时设备指纹验证失败，设备: {}", username, formatDeviceIdForLog(deviceId));
-            return ApiResponse.error("设备验证失败，无法完成登出操作");
+            throw BusinessException.of(ErrorCode.ACCESS_DENIED, "设备验证失败，无法完成登出操作");
         }
 
         try {
             refreshTokenService.deleteRefreshToken(username, refreshToken, deviceId);
             log.info("用户 {} 登出成功，设备: {}", username, formatDeviceIdForLog(deviceId));
-            return ApiResponse.success("登出成功");
         } catch (Exception e) {
             log.error("用户 {} 登出失败", username, e);
-            return ApiResponse.error("登出失败");
+            throw BusinessException.of(ErrorCode.SYSTEM_ERROR, "登出失败");
         }
     }
 
@@ -331,14 +328,13 @@ public class AuthService {
      * @param username 用户名
      * @return 登出结果
      */
-    public ApiResponse<String> logoutAllDevices(String username) {
+    public void logoutAllDevices(String username) {
         try {
             refreshTokenService.deleteAllRefreshTokens(username);
             log.info("用户 {} 已登出所有设备", username);
-            return ApiResponse.success("已登出所有设备");
         } catch (Exception e) {
             log.error("用户 {} 登出所有设备失败", username, e);
-            return ApiResponse.error("登出所有设备失败");
+            throw BusinessException.of(ErrorCode.SYSTEM_ERROR, "登出所有设备失败");
         }
     }
 
@@ -350,7 +346,7 @@ public class AuthService {
      * @param request  HTTP请求对象，用于设备指纹验证（当前设备）
      * @return 操作结果
      */
-    public ApiResponse<String> kickDevice(String username, String deviceId, HttpServletRequest request) {
+    public void kickDevice(String username, String deviceId, HttpServletRequest request) {
         // 验证当前操作设备的合法性（防止恶意踢出）
         DeviceInfo currentDevice = deviceFingerprintService.generateDeviceFingerprint(request);
         String currentDeviceId = currentDevice.getDeviceId();
@@ -358,16 +354,15 @@ public class AuthService {
         // 不允许踢出自己当前使用的设备
         if (currentDeviceId.equals(deviceId)) {
             log.warn("用户 {} 尝试踢出自己当前使用的设备: {}", username, formatDeviceIdForLog(deviceId));
-            return ApiResponse.error("不能踢出当前使用的设备");
+            throw BusinessException.of(ErrorCode.ACCESS_DENIED, "不能踢出当前使用的设备");
         }
 
         try {
             refreshTokenService.deleteDeviceToken(username, deviceId);
             log.info("管理员踢出用户 {} 的设备: {}", username, formatDeviceIdForLog(deviceId));
-            return ApiResponse.success("设备已被踢出");
         } catch (Exception e) {
             log.error("踢出用户 {} 设备 {} 失败", username, deviceId, e);
-            return ApiResponse.error("踢出设备失败");
+            throw BusinessException.of(ErrorCode.SYSTEM_ERROR, "踢出设备失败");
         }
     }
 
@@ -377,13 +372,13 @@ public class AuthService {
      * @param username 用户名
      * @return 设备ID集合
      */
-    public ApiResponse<Set<String>> getUserDevices(String username) {
+    public Set<String> getUserDevices(String username) {
         try {
             Set<String> devices = refreshTokenService.getUserDevices(username);
-            return ApiResponse.success("获取设备列表成功", devices);
+            return devices;
         } catch (Exception e) {
             log.error("获取用户 {} 设备列表失败", username, e);
-            return ApiResponse.error("获取设备列表失败");
+            throw BusinessException.of(ErrorCode.SYSTEM_ERROR, "获取设备列表失败");
         }
     }
 
@@ -394,28 +389,28 @@ public class AuthService {
      * @param request                  HTTP请求对象，用于设备指纹验证
      * @return 修改结果
      */
-    public ApiResponse<String> changePassword(String username, ChangePasswordRequestDto changePasswordRequestDto,
+    public void changePassword(String username, ChangePasswordRequestDto changePasswordRequestDto,
             HttpServletRequest request) {
         String oldPassword = changePasswordRequestDto.getOldPassword();
         String newPassword = changePasswordRequestDto.getNewPassword();
 
         if (oldPassword.equals(newPassword)) {
-            return ApiResponse.error("新密码不能与旧密码相同");
+            throw BusinessException.of(ErrorCode.PARAM_ERROR, "新密码不能与旧密码相同");
         }
 
         User user = userMapper.selectOne(new LambdaQueryWrapper<User>()
                 .eq(User::getUsername, username)
                 .ne(User::getStatus, "deleted"));
         if (user == null) {
-            return ApiResponse.error("用户不存在");
+            throw BusinessException.of(ErrorCode.USER_NOT_FOUND, "用户不存在");
         }
 
         if (!user.getEmailVerified()) {
-            return ApiResponse.error("请先验证邮箱");
+            throw BusinessException.of(ErrorCode.ACCESS_DENIED, "请先验证邮箱");
         }
 
         if (!passwordEncoder.matches(oldPassword, user.getPassword())) {
-            return ApiResponse.error("旧密码不正确");
+            throw BusinessException.of(ErrorCode.PASSWORD_ERROR, "旧密码不正确");
         }
 
         user.setPassword(passwordEncoder.encode(newPassword));
@@ -433,10 +428,9 @@ public class AuthService {
                     request.getRemoteAddr());
 
             log.info("用户 {} 修改密码成功", username);
-            return ApiResponse.success("密码修改成功");
         } catch (Exception e) {
             log.error("用户 {} 修改密码失败", username, e);
-            return ApiResponse.error("密码修改失败");
+            throw BusinessException.of(ErrorCode.SYSTEM_ERROR, "密码修改失败");
         }
     }
 
@@ -446,19 +440,19 @@ public class AuthService {
      * @param forgotPasswordRequestDto 重置密码请求
      * @return 重置结果
      */
-    public ApiResponse<String> forgotPassword(ForgotPasswordRequestDto forgotPasswordRequestDto) {
+    public void forgotPassword(ForgotPasswordRequestDto forgotPasswordRequestDto) {
         String email = forgotPasswordRequestDto.getEmail();
         User user = userMapper.selectOne(new LambdaQueryWrapper<User>()
                 .eq(User::getEmail, email)
                 .ne(User::getStatus, "deleted"));
         if (user == null) {
             log.warn("密码重置请求失败，邮箱未注册：{}", email);
-            return ApiResponse.error("邮箱未注册");
+            throw BusinessException.of(ErrorCode.USER_NOT_FOUND, "邮箱未注册");
         }
 
         if (!user.getEmailVerified()) {
             log.warn("密码重置请求失败，用户邮箱未验证：{}", email);
-            return ApiResponse.error("请先验证邮箱");
+            throw BusinessException.of(ErrorCode.ACCESS_DENIED, "请先验证邮箱");
         }
 
         try {
@@ -475,10 +469,9 @@ public class AuthService {
                     resetToken);
 
             log.info("密码重置邮件已发送至：{}", email);
-            return ApiResponse.success("密码重置邮件已发送，请检查您的邮箱");
         } catch (Exception e) {
             log.error("发送密码重置邮件失败，邮箱：{}", email, e);
-            return ApiResponse.error("发送密码重置邮件失败，请稍后重试");
+            throw BusinessException.of(ErrorCode.EMAIL_SEND_FAILED, "发送密码重置邮件失败，请稍后重试");
         }
     }
 
@@ -488,7 +481,7 @@ public class AuthService {
      * @param resetPasswordRequestDto 重置密码请求
      * @return 重置结果
      */
-    public ApiResponse<String> resetPassword(ResetPasswordRequestDto resetPasswordRequestDto) {
+    public void resetPassword(ResetPasswordRequestDto resetPasswordRequestDto) {
         String resetToken = resetPasswordRequestDto.getResetToken();
         String newPassword = resetPasswordRequestDto.getNewPassword();
         String redisKey = UserKey.buildPasswordResetKey(resetToken);
@@ -496,7 +489,7 @@ public class AuthService {
         Map<Object, Object> resetData = redisService.hGetAll(redisKey);
         if (resetData == null || resetData.isEmpty()) {
             log.warn("密码重置失败，令牌无效或已过期，令牌: {}", resetToken);
-            return ApiResponse.error("密码重置令牌无效或已过期");
+            throw BusinessException.of(ErrorCode.TOKEN_INVALID, "密码重置令牌无效或已过期");
         }
 
         Long userId = (Long) resetData.get("userId");
@@ -505,11 +498,11 @@ public class AuthService {
                 .ne(User::getStatus, "deleted"));
         if (user == null) {
             log.error("密码重置失败，用户不存在，用户ID: {}", userId);
-            return ApiResponse.error("用户不存在");
+            throw BusinessException.of(ErrorCode.USER_NOT_FOUND, "用户不存在");
         }
 
         if (passwordEncoder.matches(newPassword, user.getPassword())) {
-            return ApiResponse.error("新密码不能与旧密码相同");
+            throw BusinessException.of(ErrorCode.PARAM_ERROR, "新密码不能与旧密码相同");
         }
 
         user.setPassword(passwordEncoder.encode(newPassword));
@@ -521,10 +514,9 @@ public class AuthService {
             refreshTokenService.deleteAllRefreshTokens(user.getUsername());
 
             log.info("用户 {} 的密码重置成功", user.getUsername());
-            return ApiResponse.success("密码重置成功");
         } catch (Exception e) {
             log.error("用户 {} 的密码重置失败", user.getUsername(), e);
-            return ApiResponse.error("密码重置失败，请稍后重试");
+            throw BusinessException.of(ErrorCode.SYSTEM_ERROR, "密码重置失败，请稍后重试");
         }
     }
 
@@ -535,21 +527,20 @@ public class AuthService {
      * @param request  HTTP请求对象，用于设备指纹验证
      * @return 清理结果
      */
-    public ApiResponse<String> cleanExpiredTokens(String username, HttpServletRequest request) {
+    public void cleanExpiredTokens(String username, HttpServletRequest request) {
         // 验证当前设备的合法性
         DeviceInfo currentDevice = deviceFingerprintService.generateDeviceFingerprint(request);
         if (!validateDeviceFingerprint(request, username, currentDevice.getDeviceId())) {
             log.warn("用户 {} 清理过期令牌时设备指纹验证失败", username);
-            return ApiResponse.error("设备验证失败，无法执行清理操作");
+            throw BusinessException.of(ErrorCode.ACCESS_DENIED, "设备验证失败，无法执行清理操作");
         }
 
         try {
             refreshTokenService.cleanExpiredTokens(username);
             log.debug("清理用户 {} 的过期令牌完成", username);
-            return ApiResponse.success("清理过期令牌成功");
         } catch (Exception e) {
             log.error("清理用户 {} 过期令牌失败", username, e);
-            return ApiResponse.error("清理过期令牌失败");
+            throw BusinessException.of(ErrorCode.SYSTEM_ERROR, "清理过期令牌失败");
         }
     }
 

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/AuthService.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/auth/service/AuthService.java
@@ -203,6 +203,44 @@ public class AuthService {
     }
 
     /**
+     * 重新发送验证邮件
+     */
+    public void resendVerificationEmail(Long userId) {
+        User user = userMapper.selectOne(new LambdaQueryWrapper<User>()
+                .eq(User::getId, userId)
+                .ne(User::getStatus, "deleted"));
+        if (user == null) {
+            log.warn("重新发送验证邮件失败，邮箱未注册");
+            throw BusinessException.of(ErrorCode.USER_NOT_FOUND, "邮箱未注册");
+        }
+
+        if (user.getEmailVerified()) {
+            log.info("用户 {} 的邮箱已验证，无需重新发送验证邮件", user.getUsername());
+            return;
+        }
+
+        try {
+            // 生成新的邮箱验证令牌
+            String emailToken = UUID.randomUUID().toString();
+            String redisKey = UserKey.buildEmailVerificationKey(emailToken);
+            RedisService.hSet(redisKey, "userId", user.getId());
+            RedisService.expire(redisKey, 24 * 60 * 60); // 24小时过期
+
+            // 发送验证邮件
+            emailEventPublisher.publishUserRegistrationEvent(
+                    user.getEmail(),
+                    user.getId(),
+                    user.getUsername(),
+                    emailToken);
+
+            log.info("验证邮件已重新发送至");
+        } catch (Exception e) {
+            log.error("重新发送验证邮件失败", e);
+            throw BusinessException.of(ErrorCode.EMAIL_SEND_FAILED, "重新发送验证邮件失败，请稍后重试");
+        }
+    }
+
+    /**
      * 验证用户邮箱
      *
      * @param verifyEmailRequestDto 验证请求
@@ -240,10 +278,10 @@ public class AuthService {
             userMapper.updateById(user);
             // 删除整个key
             redisService.delete(redisKey);
-            
+
             // 邮箱验证成功后，将用户从 GUEST 角色升级到 USER 角色
             upgradeUserFromGuestToUser(user.getId());
-            
+
             log.info("用户 {} 的邮箱验证成功", user.getUsername());
         } catch (Exception e) {
             log.error("更新用户 {} 的邮箱验证状态失败", user.getUsername(), e);
@@ -586,7 +624,7 @@ public class AuthService {
                 userRoleService.assignRoleToUser(userId, userRole.getId());
                 log.info("用户 {} 从 GUEST 角色升级到 USER 角色成功", userId);
             } else {
-                log.warn("角色不存在：GUEST={}, USER={}，无法为用户 {} 升级角色", 
+                log.warn("角色不存在：GUEST={}, USER={}，无法为用户 {} 升级角色",
                     guestRole != null, userRole != null, userId);
             }
         } catch (Exception e) {

--- a/backend/blog-backend/src/main/java/com/kisesaki/blog/user/controller/UserController.java
+++ b/backend/blog-backend/src/main/java/com/kisesaki/blog/user/controller/UserController.java
@@ -3,7 +3,6 @@ package com.kisesaki.blog.user.controller;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.kisesaki.blog.common.dto.ApiResponse;
+import com.kisesaki.blog.common.dto.ResultUtils;
 import com.kisesaki.blog.common.util.AuthUtils;
 import com.kisesaki.blog.file.FileUploadService;
 import com.kisesaki.blog.user.dto.UserStatsDto;
@@ -54,62 +54,62 @@ public class UserController {
     @PostMapping("/getUserInfoByToken")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "根据token获取当前用户信息", description = "获取当前登录用户的详细信息")
-    public ResponseEntity<ApiResponse<UserInfoDto>> getUserInfoByToken(Authentication authentication) {
+    public ApiResponse<UserInfoDto> getUserInfoByToken(Authentication authentication) {
         String username = AuthUtils.getUsernameFromAuthentication(authentication);
         UserInfoDto userInfo = userService.getUserInfoByUsername(username);
-        return ResponseEntity.ok(ApiResponse.success(userInfo));
+        return ResultUtils.success("获取用户信息成功", userInfo);
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "根据用户ID获取用户信息", description = "获取指定用户的详细信息")
-    public ResponseEntity<ApiResponse<UserInfoDto>> getUserInfoById(
+    public ApiResponse<UserInfoDto> getUserInfoById(
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {
         UserInfoDto userInfo = userService.getUserInfoById(id);
-        return ResponseEntity.ok(ApiResponse.success(userInfo));
+        return ResultUtils.success("获取用户信息成功", userInfo);
     }
 
     @GetMapping("/username/{username}")
     @Operation(summary = "根据用户名获取用户信息", description = "根据用户名获取用户的详细信息")
-    public ResponseEntity<ApiResponse<UserInfoDto>> getUserInfoByUsername(
+    public ApiResponse<UserInfoDto> getUserInfoByUsername(
             @Parameter(description = "用户名", required = true) @PathVariable String username) {
         UserInfoDto userInfo = userService.getUserInfoByUsername(username);
-        return ResponseEntity.ok(ApiResponse.success(userInfo));
+        return ResultUtils.success("获取用户信息成功", userInfo);
     }
 
     @GetMapping("/{id}/profile")
     @Operation(summary = "获取用户简要信息", description = "获取用户的简要信息用于展示")
-    public ResponseEntity<ApiResponse<UserProfileDto>> getUserProfile(
+    public ApiResponse<UserProfileDto> getUserProfile(
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {
         UserProfileDto userProfile = userService.getUserProfile(id);
-        return ResponseEntity.ok(ApiResponse.success(userProfile));
+        return ResultUtils.success("获取用户简要信息成功", userProfile);
     }
 
     @PutMapping("/profile")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "更新用户资料", description = "更新当前用户的个人资料")
-    public ResponseEntity<ApiResponse<UserInfoDto>> updateProfile(
+    public ApiResponse<UserInfoDto> updateProfile(
             Authentication authentication,
             @Valid @RequestBody UpdateProfileDto updateDto) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         UserInfoDto updatedUserInfo = userService.updateUserProfile(userId, updateDto);
-        return ResponseEntity.ok(ApiResponse.success(updatedUserInfo));
+        return ResultUtils.success("更新用户资料成功", updatedUserInfo);
     }
 
     @PostMapping("/avatar")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "更新用户头像", description = "更新当前用户的头像")
-    public ResponseEntity<ApiResponse<UserInfoDto>> updateAvatar(
+    public ApiResponse<UserInfoDto> updateAvatar(
             Authentication authentication,
             @RequestParam("avatarUrl") String avatarUrl) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         UserInfoDto updatedUserInfo = userService.updateUserAvatar(userId, avatarUrl);
-        return ResponseEntity.ok(ApiResponse.success(updatedUserInfo));
+        return ResultUtils.success("更新用户头像成功", updatedUserInfo);
     }
 
     @PostMapping("/upload-avatar")
     @PreAuthorize("hasAuthority('FILE_UPLOAD')")
     @Operation(summary = "上传用户头像", description = "上传并更新当前用户的头像文件")
-    public ResponseEntity<ApiResponse<UserInfoDto>> uploadAvatar(
+    public ApiResponse<UserInfoDto> uploadAvatar(
             Authentication authentication,
             @RequestParam("file") MultipartFile file) {
         try {
@@ -120,54 +120,54 @@ public class UserController {
 
             // 更新用户头像
             UserInfoDto updatedUserInfo = userService.updateUserAvatar(userId, avatarUrl);
-            return ResponseEntity.ok(ApiResponse.success(updatedUserInfo));
+            return ResultUtils.success("头像上传成功", updatedUserInfo);
         } catch (Exception e) {
-            return ResponseEntity.badRequest().body(ApiResponse.error("头像上传失败: " + e.getMessage()));
+            return ResultUtils.error("头像上传失败: " + e.getMessage());
         }
     }
 
     @GetMapping("/{id}/stats")
     @Operation(summary = "获取用户统计信息", description = "获取用户的统计数据")
-    public ResponseEntity<ApiResponse<UserStatsDto>> getUserStats(
+    public ApiResponse<UserStatsDto> getUserStats(
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {
         UserStatsDto userStats = userService.getUserStats(id);
-        return ResponseEntity.ok(ApiResponse.success(userStats));
+        return ResultUtils.success("获取用户统计信息成功", userStats);
     }
 
     @GetMapping("/settings")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "获取用户设置", description = "获取当前用户的所有设置")
-    public ResponseEntity<ApiResponse<Map<String, String>>> getUserSettings(Authentication authentication) {
+    public ApiResponse<Map<String, String>> getUserSettings(Authentication authentication) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         Map<String, String> settings = userSettingsService.getUserSettings(userId);
-        return ResponseEntity.ok(ApiResponse.success(settings));
+        return ResultUtils.success("获取用户设置成功", settings);
     }
 
     @PutMapping("/settings")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "更新用户设置", description = "批量更新用户设置")
-    public ResponseEntity<ApiResponse<String>> updateUserSettings(
+    public ApiResponse<String> updateUserSettings(
             Authentication authentication,
             @Valid @RequestBody UserSettingsDto settingsDto) {
         Long userId = AuthUtils.getUserIdFromAuthentication(authentication);
         userSettingsService.setUserSettings(userId, settingsDto.getSettings());
-        return ResponseEntity.ok(ApiResponse.success("设置更新成功"));
+        return ResultUtils.success("设置更新成功", "");
     }
 
     @GetMapping("/check/username")
     @Operation(summary = "检查用户名是否可用", description = "检查用户名是否已被使用")
-    public ResponseEntity<ApiResponse<Boolean>> checkUsernameAvailability(
+    public ApiResponse<Boolean> checkUsernameAvailability(
             @Parameter(description = "用户名", required = true) @RequestParam String username) {
         boolean available = userService.isUsernameAvailable(username);
-        return ResponseEntity.ok(ApiResponse.success(available));
+        return ResultUtils.success("检查用户名可用性成功", available);
     }
 
     @GetMapping("/check/email")
     @Operation(summary = "检查邮箱是否可用", description = "检查邮箱是否已被注册")
-    public ResponseEntity<ApiResponse<Boolean>> checkEmailAvailability(
+    public ApiResponse<Boolean> checkEmailAvailability(
             @Parameter(description = "邮箱", required = true) @RequestParam String email) {
         boolean available = userService.isEmailAvailable(email);
-        return ResponseEntity.ok(ApiResponse.success(available));
+        return ResultUtils.success("检查邮箱可用性成功", available);
     }
 
     // ===== 关注相关接口 =====
@@ -175,65 +175,65 @@ public class UserController {
     @PostMapping("/{id}/follow")
     @Operation(summary = "关注用户", description = "关注指定用户")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse<String>> followUser(
+    public ApiResponse<String> followUser(
             Authentication authentication,
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {
         Long currentUserId = AuthUtils.getUserIdFromAuthentication(authentication);
         boolean success = userFollowService.followUser(currentUserId, id);
 
         if (success) {
-            return ResponseEntity.ok(ApiResponse.success("关注成功"));
+            return ResultUtils.success("关注成功", "");
         } else {
-            return ResponseEntity.badRequest().body(ApiResponse.error("关注失败"));
+            return ResultUtils.error("关注失败");
         }
     }
 
     @PostMapping("/{id}/unfollow")
     @Operation(summary = "取消关注用户", description = "取消关注指定用户")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse<String>> unfollowUser(
+    public ApiResponse<String> unfollowUser(
             Authentication authentication,
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {
         Long currentUserId = AuthUtils.getUserIdFromAuthentication(authentication);
         boolean success = userFollowService.unfollowUser(currentUserId, id);
 
         if (success) {
-            return ResponseEntity.ok(ApiResponse.success("取消关注成功"));
+            return ResultUtils.success("取消关注成功", "");
         } else {
-            return ResponseEntity.badRequest().body(ApiResponse.error("取消关注失败"));
+            return ResultUtils.error("取消关注失败");
         }
     }
 
     @GetMapping("/{id}/is-following")
     @Operation(summary = "检查是否已关注", description = "检查当前用户是否已关注指定用户")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse<Boolean>> isFollowing(
+    public ApiResponse<Boolean> isFollowing(
             Authentication authentication,
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {
         Long currentUserId = AuthUtils.getUserIdFromAuthentication(authentication);
         boolean isFollowing = userFollowService.isFollowing(currentUserId, id);
-        return ResponseEntity.ok(ApiResponse.success(isFollowing));
+        return ResultUtils.success("检查关注状态成功", isFollowing);
     }
 
     @GetMapping("/{id}/following")
     @Operation(summary = "获取用户关注列表", description = "获取指定用户关注的人列表")
-    public ResponseEntity<ApiResponse<List<UserFollowDto>>> getFollowingList(
+    public ApiResponse<List<UserFollowDto>> getFollowingList(
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {
         List<UserFollowDto> followingList = userFollowService.getFollowingList(id);
-        return ResponseEntity.ok(ApiResponse.success(followingList));
+        return ResultUtils.success("获取关注列表成功", followingList);
     }
 
     @GetMapping("/{id}/followers")
     @Operation(summary = "获取用户粉丝列表", description = "获取关注指定用户的人列表")
-    public ResponseEntity<ApiResponse<List<UserFollowDto>>> getFollowersList(
+    public ApiResponse<List<UserFollowDto>> getFollowersList(
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {
         List<UserFollowDto> followersList = userFollowService.getFollowersList(id);
-        return ResponseEntity.ok(ApiResponse.success(followersList));
+        return ResultUtils.success("获取粉丝列表成功", followersList);
     }
 
     @GetMapping("/{id}/follow-counts")
     @Operation(summary = "获取用户关注统计", description = "获取用户的关注数和粉丝数")
-    public ResponseEntity<ApiResponse<Map<String, Long>>> getFollowCounts(
+    public ApiResponse<Map<String, Long>> getFollowCounts(
             @Parameter(description = "用户ID", required = true) @PathVariable Long id) {
         long followingCount = userFollowService.getFollowingCount(id);
         long followersCount = userFollowService.getFollowersCount(id);
@@ -242,7 +242,7 @@ public class UserController {
                 "followingCount", followingCount,
                 "followersCount", followersCount);
 
-        return ResponseEntity.ok(ApiResponse.success(counts));
+        return ResultUtils.success("获取关注统计成功", counts);
     }
 
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -32,6 +32,12 @@ export const registerApi = (params: RegisterParams) =>
   httpClient.post<string>('/auth/register', params);
 
 /**
+ * 重新发送验证邮箱
+ */
+export const resendVerificationEmailApi = () =>
+  httpClient.post<string>('/auth/resend-verification-email');
+
+/**
  * 验证邮箱
  * @param params 验证邮箱参数
  * @returns 验证结果

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { loginApi } from '@/api/auth';
+import { loginApi, resendVerificationEmailApi } from '@/api/auth';
 import { getUserInfoByTokenApi } from '@/api/user';
 import { useAuthStore } from '@/stores';
 import type { LoginParams, UserInfo } from '@/types';
@@ -25,6 +25,8 @@ export const useAuth = () => {
   } = useAuthStore();
 
   const [loginLoading, setLoginLoading] = useState(false);
+  const [resendVerificationLoading, setResendVerificationLoading] =
+    useState(false);
 
   /**
    * 获取用户信息
@@ -102,6 +104,24 @@ export const useAuth = () => {
     return await fetchUserInfo();
   }, [setUserLoaded, fetchUserInfo]);
 
+  /**
+   * 重新发送验证邮件
+   */
+  const resendVerificationEmail = useCallback(async (): Promise<boolean> => {
+    try {
+      setResendVerificationLoading(true);
+      await resendVerificationEmailApi();
+      toast.success('验证邮件已发送，请检查您的邮箱');
+      return true;
+    } catch (error) {
+      console.error('发送验证邮件失败:', error);
+      toast.error('发送验证邮件失败，请稍后重试');
+      return false;
+    } finally {
+      setResendVerificationLoading(false);
+    }
+  }, []);
+
   return {
     // 状态
     user,
@@ -109,6 +129,7 @@ export const useAuth = () => {
     isAuthenticated,
     isLoading,
     loginLoading,
+    resendVerificationLoading,
     userLoaded,
 
     // 操作
@@ -116,6 +137,7 @@ export const useAuth = () => {
     fetchUserInfo,
     refreshUserInfo,
     updateCurrentUser,
+    resendVerificationEmail,
     logout,
     setLoading,
   };

--- a/frontend/src/lib/client.ts
+++ b/frontend/src/lib/client.ts
@@ -1,4 +1,9 @@
-import { API_CONFIG, ENV_CONFIG, LOGIN_LINK, PAGINATION_CONFIG } from '@/config';
+import {
+  API_CONFIG,
+  ENV_CONFIG,
+  LOGIN_LINK,
+  PAGINATION_CONFIG,
+} from '@/config';
 import axios, {
   type AxiosError,
   type AxiosInstance,
@@ -163,7 +168,7 @@ class HttpClient {
 
       // 认证错误处理
       if (category === ErrorCategory.AUTH) {
-        this.handleAuthError(errorCode, config);
+        this.handleAuthError(errorCode, config, error.config?.url);
         return; // 认证错误不显示通用错误提示
       }
     }
@@ -185,10 +190,18 @@ class HttpClient {
   /**
    * 处理认证相关错误
    */
-  private handleAuthError(errorCode: ErrorCodeType, config?: ApiRequestConfig) {
+  private handleAuthError(
+    errorCode: ErrorCodeType,
+    config?: ApiRequestConfig,
+    url?: string
+  ) {
     // 需要重新登录的错误
     if (isLoginRequiredError(errorCode)) {
-      this.handleUnauthorized();
+      // 特殊处理：验证邮箱接口的token失效不跳转登录
+      const isVerifyEmailRequest = url?.includes('/auth/verify-email');
+      if (!isVerifyEmailRequest) {
+        this.handleUnauthorized();
+      }
       if (
         config?.showError !== false &&
         config?.silent !== true &&

--- a/frontend/src/pages/User/profile/UserProfile.tsx
+++ b/frontend/src/pages/User/profile/UserProfile.tsx
@@ -14,7 +14,7 @@ import {
   UserAvatarUploader,
   UserLayout,
 } from '@/components';
-import { useUser } from '@/hooks';
+import { useAuth, useUser } from '@/hooks';
 import type { UserInfo } from '@/types';
 import { SelectValue } from '@radix-ui/react-select';
 import { useForm } from 'react-hook-form';
@@ -27,6 +27,7 @@ import { useUserProfile } from './hooks/useUserProfile';
 const UserProfile = () => {
   const { userInfo } = useUserProfile();
   const { profile, loading } = useUser();
+  const { resendVerificationEmail, resendVerificationLoading } = useAuth();
   const form = useForm<UserInfo>({
     defaultValues: {
       displayName: userInfo?.displayName || '',
@@ -103,6 +104,20 @@ const UserProfile = () => {
                     <FormItem>
                       <FormLabel>邮箱</FormLabel>
                       <Input disabled placeholder='邮箱' {...field} />
+                      {!userInfo?.emailVerified && (
+                        <p className='mt-1 text-sm text-red-600'>
+                          未验证邮箱，点击
+                          <a
+                            className='underline cursor-pointer'
+                            onClick={() => resendVerificationEmail()}
+                          >
+                            重新发送验证邮件
+                          </a>
+                          {resendVerificationLoading && (
+                            <span className='ml-2 text-xs'>发送中...</span>
+                          )}
+                        </p>
+                      )}
                     </FormItem>
                   )}
                 />


### PR DESCRIPTION
### **描述 (Description)**

本次 Pull Request 的主要目标：

- 添加重新发送验证邮件功能，支持用户在注册后重新发送验证邮件
- 重构认证服务和控制器，简化响应结构
- 优化 HttpClient 的认证错误处理，特殊处理验证邮箱接口的 token 失效情况

此改动涉及的模块：

- `backend/blog-backend/src/main/java/com/kisesaki/blog/auth/`
- `backend/blog-backend/src/main/java/com/kisesaki/blog/common/`

---

### **主要变更 (Changes)**

- **新增**: 重新发送验证邮件的 API 接口和业务逻辑
- **修改**: 认证服务 (AuthService) 和控制器 (AuthController)，简化响应结构
- **优化/重构**: HttpClient 的认证错误处理逻辑，针对验证邮箱接口的 token 失效进行特殊处理

---

### **影响范围 (Impact)**

- 影响的功能/模块：用户注册和邮箱验证流程
- 是否涉及数据库/接口/配置变更：涉及后端 API 接口变更，前端可能需要相应调整
- 是否存在向下兼容性风险：存在一定向下兼容性风险，建议前端同步更新以支持新接口